### PR TITLE
Update auto-translate workflow to trigger on strings.xml changes and manual run

### DIFF
--- a/.github/workflows/auto-translate.yaml
+++ b/.github/workflows/auto-translate.yaml
@@ -4,7 +4,10 @@ on:
   push:
     branches:
       - main
-
+    paths:
+      - '**/values/strings.xml'
+  workflow_dispatch:
+    
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow configuration to trigger the workflow on changes to specific files. The most important change is:

* [`.github/workflows/auto-translate.yaml`](diffhunk://#diff-28b5cad39ec4fe41895e1f880bf60b01b284567358bfc0222483e3c31fee5874R7-R9): Added `paths` configuration to trigger the workflow when changes are made to any `strings.xml` files within the project directory.