### PR TITLE
feat: Update translations to use quotation marks in accessibility explainer

### DIFF
--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -9,8 +9,8 @@
     <string name="accessibility_explainer_open_source">Naš kod je 100\% otvorenog koda na GitHub-u.</string>
     <string name="accessibility_explainer_privacy_note">Cenimo vašu privatnost. Scrolless koristi ovu dozvolu samo za otkrivanje i zaustavljanje kratkog sadržaja. Ne prikupljamo nikakve lične informacije.</string>
     <string name="accessibility_explainer_proceed_button">Idite na Podešavanja</string>
-    <string name="accessibility_explainer_step1">Dodirnite "Idite na Podešavanja" ispod da otvorite Androidove postavke pristupačnosti</string>
-    <string name="accessibility_explainer_step2">Pronađite aplikacije i dodirnite "Scrolless" na listi usluga</string>
+    <string name="accessibility_explainer_step1">Dodirnite \"Idite na Podešavanja\" ispod da otvorite Androidove postavke pristupačnosti</string>
+    <string name="accessibility_explainer_step2">Pronađite aplikacije i dodirnite \"Scrolless\" na listi usluga</string>
     <string name="accessibility_explainer_step3">Prebacite prekidač na UKLJUČENO da omogućite Scrolless da vam pomogne da prekinete beskrajno skrolovanje.</string>
     <string name="accessibility_explainer_subtitle">Scrolless zahteva pristup pristupačnosti kako bi otkrio i zaustavio kratke video snimke.</string>
     <string name="accessibility_explainer_title">Potrebna nam je pristupnost</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -9,8 +9,8 @@
     <string name="accessibility_explainer_open_source">El nostre codi és 100\% de codi obert a GitHub.</string>
     <string name="accessibility_explainer_privacy_note">Valorem la vostra privadesa. Scrolless només utilitza aquest permís per detectar i aturar contingut de format breu. No recopilem cap informació personal.</string>
     <string name="accessibility_explainer_proceed_button">Vés a Configuració</string>
-    <string name="accessibility_explainer_step1">Toca "Vés a Configuració" a continuació per obrir la configuració d\'Accessibilitat d\'Android</string>
-    <string name="accessibility_explainer_step2">Troba aplicacions i toca "Scrolless" a la llista de serveis</string>
+    <string name="accessibility_explainer_step1">Toca \"Vés a Configuració\" a continuació per obrir la configuració d\'Accessibilitat d\'Android</string>
+    <string name="accessibility_explainer_step2">Troba aplicacions i toca \"Scrolless\" a la llista de serveis</string>
     <string name="accessibility_explainer_step3">Activa l\'interruptor per habilitar Scrolless i ajudar-te a aturar el desplaçament sense fi.</string>
     <string name="accessibility_explainer_subtitle">Scrolless necessita accés d\'accessibilitat per detectar i aturar vídeos curts.</string>
     <string name="accessibility_explainer_title">Necessitem accés a l\'accessibilitat</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -9,8 +9,8 @@
     <string name="accessibility_explainer_open_source">Náš kód je 100\% open source na GitHubu.</string>
     <string name="accessibility_explainer_privacy_note">Ceníme si vašeho soukromí. Scrolless používá toto oprávnění pouze k detekci a zastavení krátkého obsahu. Neshromažďujeme žádné osobní informace.</string>
     <string name="accessibility_explainer_proceed_button">Přejít do nastavení</string>
-    <string name="accessibility_explainer_step1">Klepněte na "Přejít do nastavení" níže pro otevření nastavení přístupnosti systému Android</string>
-    <string name="accessibility_explainer_step2">Najděte aplikace a klepněte na "Scrolless" v seznamu služeb</string>
+    <string name="accessibility_explainer_step1">Klepněte na \"Přejít do nastavení\" níže pro otevření nastavení přístupnosti systému Android</string>
+    <string name="accessibility_explainer_step2">Najděte aplikace a klepněte na \"Scrolless\" v seznamu služeb</string>
     <string name="accessibility_explainer_step3">Přepněte přepínač na ZAPNUTO, aby Scrolless mohl pomoci zastavit nekonečné scrollování.</string>
     <string name="accessibility_explainer_subtitle">Scrolless potřebuje přístup k přístupnosti, aby detekoval a zastavil krátká videa.</string>
     <string name="accessibility_explainer_title">Potřebujeme přístup k přístupnosti</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -9,8 +9,8 @@
     <string name="accessibility_explainer_open_source">Unser Code ist zu 100 \% Open Source auf GitHub.</string>
     <string name="accessibility_explainer_privacy_note">Wir schätzen Ihre Privatsphäre. Scrolless verwendet diese Berechtigung nur, um Kurzforminhalte zu erkennen und zu stoppen. Wir sammeln keine persönlichen Informationen.</string>
     <string name="accessibility_explainer_proceed_button">Gehe zu Einstellungen</string>
-    <string name="accessibility_explainer_step1">Tippe unten auf "Zu den Einstellungen gehen", um die Barrierefreiheitseinstellungen von Android zu öffnen.</string>
-    <string name="accessibility_explainer_step2">Finden Sie Anwendungen und tippen Sie auf "Scrolless" in der Liste der Dienste</string>
+    <string name="accessibility_explainer_step1">Tippe unten auf \"Zu den Einstellungen gehen\", um die Barrierefreiheitseinstellungen von Android zu öffnen.</string>
+    <string name="accessibility_explainer_step2">Finden Sie Anwendungen und tippen Sie auf \"Scrolless\" in der Liste der Dienste</string>
     <string name="accessibility_explainer_step3">Schalten Sie den Schalter auf EIN, um Scrolless zu aktivieren, damit Sie das endlose Scrollen stoppen können.</string>
     <string name="accessibility_explainer_subtitle">Scrolless benötigt Zugriffsrechte für die Barrierefreiheit, um kurze Videos zu erkennen und zu stoppen.</string>
     <string name="accessibility_explainer_title">Wir benötigen Zugriff auf die Barrierefreiheit</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -9,8 +9,8 @@
     <string name="accessibility_explainer_open_source">Ο κώδικάς μας είναι 100\% ανοιχτού κώδικα στο GitHub.</string>
     <string name="accessibility_explainer_privacy_note">Εκτιμούμε την ιδιωτικότητά σας. Το Scrolless χρησιμοποιεί αυτή την άδεια μόνο για να ανιχνεύει και να σταματά περιεχόμενο μικρού μήκους. Δεν συλλέγουμε καμία προσωπική πληροφορία.</string>
     <string name="accessibility_explainer_proceed_button">Μετάβαση στις Ρυθμίσεις</string>
-    <string name="accessibility_explainer_step1">Πατήστε "Μετάβαση στις Ρυθμίσεις" παρακάτω για να ανοίξετε τις ρυθμίσεις Προσβασιμότητας του Android</string>
-    <string name="accessibility_explainer_step2">Βρείτε εφαρμογές και πατήστε στο "Scrolless" στη λίστα υπηρεσιών</string>
+    <string name="accessibility_explainer_step1">Πατήστε \"Μετάβαση στις Ρυθμίσεις\" παρακάτω για να ανοίξετε τις ρυθμίσεις Προσβασιμότητας του Android</string>
+    <string name="accessibility_explainer_step2">Βρείτε εφαρμογές και πατήστε στο \"Scrolless\" στη λίστα υπηρεσιών</string>
     <string name="accessibility_explainer_step3">Ενεργοποιήστε τον διακόπτη για να επιτρέψετε στο Scrolless να σας βοηθήσει να σταματήσετε το ατελείωτο scrolling.</string>
     <string name="accessibility_explainer_subtitle">Η εφαρμογή Scrolless χρειάζεται πρόσβαση προσβασιμότητας για να ανιχνεύσει και να σταματήσει τα σύντομα βίντεο.</string>
     <string name="accessibility_explainer_title">Χρειαζόμαστε πρόσβαση προσβασιμότητας</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -9,8 +9,8 @@
     <string name="accessibility_explainer_open_source">Nuestro código es 100\% de código abierto en GitHub.</string>
     <string name="accessibility_explainer_privacy_note">Valoramos su privacidad. Scrolless solo utiliza este permiso para detectar y detener contenido de formato corto. No recopilamos ninguna información personal.</string>
     <string name="accessibility_explainer_proceed_button">Ir a Configuración</string>
-    <string name="accessibility_explainer_step1">Toca "Ir a Configuración" abajo para abrir la configuración de Accesibilidad de Android.</string>
-    <string name="accessibility_explainer_step2">Encuentra aplicaciones y toca "Scrolless" en la lista de servicios</string>
+    <string name="accessibility_explainer_step1">Toca \"Ir a Configuración\" abajo para abrir la configuración de Accesibilidad de Android.</string>
+    <string name="accessibility_explainer_step2">Encuentra aplicaciones y toca \"Scrolless\" en la lista de servicios</string>
     <string name="accessibility_explainer_step3">Activa el interruptor para habilitar Scrolless y ayudarte a detener el desplazamiento infinito.</string>
     <string name="accessibility_explainer_subtitle">Scrolless necesita acceso de accesibilidad para detectar y detener videos cortos.</string>
     <string name="accessibility_explainer_title">Necesitamos acceso a la accesibilidad</string>

--- a/app/src/main/res/values-fi-rFI/strings.xml
+++ b/app/src/main/res/values-fi-rFI/strings.xml
@@ -9,8 +9,8 @@
     <string name="accessibility_explainer_open_source">Koodimme on 100 \% avointa lähdekoodia GitHubissa.</string>
     <string name="accessibility_explainer_privacy_note">Arvostamme yksityisyyttäsi. Scrolless käyttää tätä lupaa vain lyhyen muotoisen sisällön havaitsemiseen ja estämiseen. Emme kerää mitään henkilökohtaisia tietoja.</string>
     <string name="accessibility_explainer_proceed_button">Siirry asetuksiin</string>
-    <string name="accessibility_explainer_step1">Napauta "Siirry asetuksiin" alla avataksesi Androidin saavutettavuusasetukset.</string>
-    <string name="accessibility_explainer_step2">Etsi sovelluksia ja napauta "Scrolless" palveluiden listalta</string>
+    <string name="accessibility_explainer_step1">Napauta \"Siirry asetuksiin\" alla avataksesi Androidin saavutettavuusasetukset.</string>
+    <string name="accessibility_explainer_step2">Etsi sovelluksia ja napauta \"Scrolless\" palveluiden listalta</string>
     <string name="accessibility_explainer_step3">Kytke kytkin PÄÄLLE, jotta Scrolless voi auttaa sinua lopettamaan loputtoman selaamisen.</string>
     <string name="accessibility_explainer_subtitle">Scrolless tarvitsee saavutettavuusluvan havaitakseen ja estääkseen lyhyet videot.</string>
     <string name="accessibility_explainer_title">Tarvitsemme saavutettavuusoikeudet</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -8,9 +8,9 @@
     <string name="accessibility_explainer_not_now_button">Pas maintenant</string>
     <string name="accessibility_explainer_open_source">Notre code est 100 \% open source sur GitHub.</string>
     <string name="accessibility_explainer_privacy_note">Nous valorisons votre vie privée. Scrolless utilise cette autorisation uniquement pour détecter et arrêter le contenu de courte durée. Nous ne collectons aucune information personnelle.</string>
-    <string name="accessibility_explainer_proceed_button">Allez dans les paramètres</string>
-    <string name="accessibility_explainer_step1">Appuyez sur "Accéder aux paramètres" ci-dessous pour ouvrir les paramètres d\'accessibilité d\'Android.</string>
-    <string name="accessibility_explainer_step2">Trouvez des applications et appuyez sur "Scrolless" dans la liste des services</string>
+    <string name="accessibility_explainer_proceed_button">Accéder aux paramètres</string>
+    <string name="accessibility_explainer_step1">Appuyez sur \"Accéder aux paramètres\" ci-dessous pour ouvrir les paramètres d\'accessibilité d\'Android.</string>
+    <string name="accessibility_explainer_step2">Trouvez des applications et appuyez sur \"Scrolless\" dans la liste des services</string>
     <string name="accessibility_explainer_step3">Activez l\'interrupteur pour permettre à Scrolless de vous aider à arrêter le défilement sans fin.</string>
     <string name="accessibility_explainer_subtitle">Scrolless a besoin d\'un accès à l\'accessibilité pour détecter et arrêter les vidéos courtes.</string>
     <string name="accessibility_explainer_title">Nous avons besoin d\'un accès à l\'accessibilité</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -9,8 +9,8 @@
     <string name="accessibility_explainer_open_source">हमारा कोड GitHub पर 100\% ओपन सोर्स है।</string>
     <string name="accessibility_explainer_privacy_note">हम आपकी गोपनीयता की सराहना करते हैं। Scrolless केवल इस अनुमति का उपयोग संक्षिप्त सामग्री का पता लगाने और रोकने के लिए करता है। हम कोई व्यक्तिगत जानकारी एकत्र नहीं करते हैं।</string>
     <string name="accessibility_explainer_proceed_button">सेटिंग्स पर जाएं</string>
-    <string name="accessibility_explainer_step1">नीचे "सेटिंग्स पर जाएं" पर टैप करें ताकि Android की पहुंच सेटिंग्स खोली जा सकें</string>
-    <string name="accessibility_explainer_step2">ऐप्लिकेशन खोजें और सेवाओं की सूची में "Scrolless" पर टैप करें</string>
+    <string name="accessibility_explainer_step1">नीचे \"सेटिंग्स पर जाएं\" पर टैप करें ताकि Android की पहुंच सेटिंग्स खोली जा सकें</string>
+    <string name="accessibility_explainer_step2">ऐप्लिकेशन खोजें और सेवाओं की सूची में \"Scrolless\" पर टैप करें</string>
     <string name="accessibility_explainer_step3">स्विच को चालू करें ताकि Scrolless आपको अंतहीन स्क्रॉलिंग रोकने में मदद कर सके।</string>
     <string name="accessibility_explainer_subtitle">Scrolless को शॉर्ट वीडियो का पता लगाने और रोकने के लिए एक्सेसिबिलिटी एक्सेस की आवश्यकता है।</string>
     <string name="accessibility_explainer_title">हमें एक्सेसिबिलिटी एक्सेस की आवश्यकता है</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -9,8 +9,8 @@
     <string name="accessibility_explainer_open_source">Naš kod je 100\% otvoren izvor na GitHubu.</string>
     <string name="accessibility_explainer_privacy_note">Cijenimo vašu privatnost. Scrolless koristi ovu dozvolu samo za otkrivanje i zaustavljanje kratkog sadržaja. Ne prikupljamo nikakve osobne informacije.</string>
     <string name="accessibility_explainer_proceed_button">Idite na Postavke</string>
-    <string name="accessibility_explainer_step1">Dodirnite "Idite na postavke" ispod za otvaranje Androidovih postavki pristupačnosti</string>
-    <string name="accessibility_explainer_step2">Pronađite aplikacije i dodirnite "Scrolless" na popisu usluga</string>
+    <string name="accessibility_explainer_step1">Dodirnite \"Idite na postavke\" ispod za otvaranje Androidovih postavki pristupačnosti</string>
+    <string name="accessibility_explainer_step2">Pronađite aplikacije i dodirnite \"Scrolless\" na popisu usluga</string>
     <string name="accessibility_explainer_step3">Prebacite prekidač na UKLJUČENO kako biste omogućili Scrolless da vam pomogne da prekinete beskrajno pomicanje.</string>
     <string name="accessibility_explainer_subtitle">Scrolless treba pristup pristupačnosti kako bi otkrio i zaustavio kratke videozapise.</string>
     <string name="accessibility_explainer_title">Trebamo pristup pristupačnosti</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -9,8 +9,8 @@
     <string name="accessibility_explainer_open_source">A kódunk 100\%-ban nyílt forráskódú a GitHubon.</string>
     <string name="accessibility_explainer_privacy_note">Tiszteletben tartjuk a magánéletét. A Scrolless ezt az engedélyt csak a rövid formátumú tartalom észlelésére és leállítására használja. Nem gyűjtünk személyes adatokat.</string>
     <string name="accessibility_explainer_proceed_button">Menj a Beállításokhoz</string>
-    <string name="accessibility_explainer_step1">Koppintson az alábbi "Beállítások megnyitása" gombra az Android hozzáférhetőségi beállításainak megnyitásához</string>
-    <string name="accessibility_explainer_step2">Keresse meg az alkalmazásokat, és érintse meg a "Scrolless" lehetőséget a szolgáltatások listájában.</string>
+    <string name="accessibility_explainer_step1">Koppintson az alábbi \"Beállítások megnyitása\" gombra az Android hozzáférhetőségi beállításainak megnyitásához</string>
+    <string name="accessibility_explainer_step2">Keresse meg az alkalmazásokat, és érintse meg a \"Scrolless\" lehetőséget a szolgáltatások listájában.</string>
     <string name="accessibility_explainer_step3">Kapcsolja be a kapcsolót, hogy a Scrolless segítsen megállítani a végtelen görgetést.</string>
     <string name="accessibility_explainer_subtitle">A Scrolless-nek hozzáférési engedélyre van szüksége a rövid videók észleléséhez és leállításához.</string>
     <string name="accessibility_explainer_title">Szükségünk van akadálymentesítési hozzáférésre</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -9,8 +9,8 @@
     <string name="accessibility_explainer_open_source">Il nostro codice è 100\% open source su GitHub.</string>
     <string name="accessibility_explainer_privacy_note">Valutiamo la tua privacy. Scrolless utilizza questo permesso solo per rilevare e fermare i contenuti brevi. Non raccogliamo alcuna informazione personale.</string>
     <string name="accessibility_explainer_proceed_button">Vai alle Impostazioni</string>
-    <string name="accessibility_explainer_step1">Tocca "Vai alle Impostazioni" qui sotto per aprire le impostazioni di Accessibilità di Android</string>
-    <string name="accessibility_explainer_step2">Trova le applicazioni e tocca "Scrolless" nell\'elenco dei servizi</string>
+    <string name="accessibility_explainer_step1">Tocca \"Vai alle Impostazioni\" qui sotto per aprire le impostazioni di Accessibilità di Android</string>
+    <string name="accessibility_explainer_step2">Trova le applicazioni e tocca \"Scrolless\" nell\'elenco dei servizi</string>
     <string name="accessibility_explainer_step3">Attiva l\'interruttore su ON per consentire a Scrolless di aiutarti a fermare lo scroll infinito</string>
     <string name="accessibility_explainer_subtitle">Scrolless ha bisogno dell\'accesso all\'accessibilità per rilevare e fermare i video brevi.</string>
     <string name="accessibility_explainer_title">Abbiamo bisogno dell\'accesso all\'accessibilità</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -9,8 +9,8 @@
     <string name="accessibility_explainer_open_source">നമ്മുടെ കോഡ് 100\% ഓപ്പൺ സോഴ്സ് ആണ് GitHub-ൽ.</string>
     <string name="accessibility_explainer_privacy_note">നിങ്ങളുടെ സ്വകാര്യതയെ ഞങ്ങൾ വിലമതിക്കുന്നു. Scrolless ഈ അനുമതി ചെറുകിട ഉള്ളടക്കം കണ്ടെത്താനും തടയാനും മാത്രം ഉപയോഗിക്കുന്നു. ഞങ്ങൾ ഏതെങ്കിലും വ്യക്തിഗത വിവരങ്ങൾ ശേഖരിക്കുന്നില്ല.</string>
     <string name="accessibility_explainer_proceed_button">സജ്ജീകരണത്തിലേക്ക് പോകുക</string>
-    <string name="accessibility_explainer_step1">താഴെ "സജ്ജീകരണത്തിലേക്ക് പോകുക" എന്നതിൽ തട്ടുക, Android-ന്റെ ആക്സസിബിലിറ്റി സജ്ജീകരണങ്ങൾ തുറക്കാൻ.</string>
-    <string name="accessibility_explainer_step2">അപ്ലിക്കേഷനുകൾ കണ്ടെത്തി സേവനങ്ങളുടെ പട്ടികയിൽ "Scrolless" എന്നതിൽ ടാപ്പ് ചെയ്യുക</string>
+    <string name="accessibility_explainer_step1">താഴെ \"സജ്ജീകരണത്തിലേക്ക് പോകുക\" എന്നതിൽ തട്ടുക, Android-ന്റെ ആക്സസിബിലിറ്റി സജ്ജീകരണങ്ങൾ തുറക്കാൻ.</string>
+    <string name="accessibility_explainer_step2">അപ്ലിക്കേഷനുകൾ കണ്ടെത്തി സേവനങ്ങളുടെ പട്ടികയിൽ \"Scrolless\" എന്നതിൽ ടാപ്പ് ചെയ്യുക</string>
     <string name="accessibility_explainer_step3">സ്ക്രോലിംഗ് അവസാനിപ്പിക്കാൻ Scrolless-നെ സഹായിക്കാൻ ON-ലേക്ക് സ്വിച്ച് മാറ്റുക</string>
     <string name="accessibility_explainer_subtitle">Scrolless-ന് ചെറുവീഡിയോകൾ കണ്ടെത്താനും നിർത്താനും ആക്സസിബിലിറ്റി ആക്സസ് ആവശ്യമാണ്.</string>
     <string name="accessibility_explainer_title">ഞങ്ങൾക്ക് ആക്സസിബിലിറ്റി ആക്സസ് ആവശ്യമുണ്ട്</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -9,8 +9,8 @@
     <string name="accessibility_explainer_open_source">Koden vår er 100 \% åpen kildekode på GitHub.</string>
     <string name="accessibility_explainer_privacy_note">Vi verdsetter ditt personvern. Scrolless bruker kun denne tillatelsen for å oppdage og stoppe kortformet innhold. Vi samler ikke inn personlig informasjon.</string>
     <string name="accessibility_explainer_proceed_button">Gå til Innstillinger</string>
-    <string name="accessibility_explainer_step1">Trykk "Gå til innstillinger" nedenfor for å åpne Androids tilgjengelighetsinnstillinger</string>
-    <string name="accessibility_explainer_step2">Finn apper og trykk på "Scrolless" i listen over tjenester</string>
+    <string name="accessibility_explainer_step1">Trykk \"Gå til innstillinger\" nedenfor for å åpne Androids tilgjengelighetsinnstillinger</string>
+    <string name="accessibility_explainer_step2">Finn apper og trykk på \"Scrolless\" i listen over tjenester</string>
     <string name="accessibility_explainer_step3">Aktiver bryteren for å la Scrolless hjelpe deg med å stoppe endeløs scrolling</string>
     <string name="accessibility_explainer_subtitle">Scrolless trenger tilgang til tilgjengelighet for å oppdage og stoppe korte videoer.</string>
     <string name="accessibility_explainer_title">Vi trenger tilgang til tilgjengelighet</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -9,8 +9,8 @@
     <string name="accessibility_explainer_open_source">Onze code is 100\% open source op GitHub.</string>
     <string name="accessibility_explainer_privacy_note">We waarderen uw privacy. Scrolless gebruikt deze toestemming alleen om korte inhoud te detecteren en te stoppen. We verzamelen geen persoonlijke informatie.</string>
     <string name="accessibility_explainer_proceed_button">Ga naar Instellingen</string>
-    <string name="accessibility_explainer_step1">Tik op "Ga naar Instellingen" hieronder om de toegankelijkheidsinstellingen van Android te openen.</string>
-    <string name="accessibility_explainer_step2">Zoek applicaties en tik op "Scrolless" in de lijst met services</string>
+    <string name="accessibility_explainer_step1">Tik op \"Ga naar Instellingen\" hieronder om de toegankelijkheidsinstellingen van Android te openen.</string>
+    <string name="accessibility_explainer_step2">Zoek applicaties en tik op \"Scrolless\" in de lijst met services</string>
     <string name="accessibility_explainer_step3">Schakel de schakelaar in op AAN om Scrolless in te schakelen en je te helpen eindeloos scrollen te stoppen.</string>
     <string name="accessibility_explainer_subtitle">Scrolless heeft toegang tot toegankelijkheidsdiensten nodig om korte video\'s te detecteren en te stoppen.</string>
     <string name="accessibility_explainer_title">We hebben toegankelijkheidstoegang nodig</string>

--- a/app/src/main/res/values-nn-rNO/strings.xml
+++ b/app/src/main/res/values-nn-rNO/strings.xml
@@ -9,8 +9,8 @@
     <string name="accessibility_explainer_open_source">Koden vår er 100 \% open source på GitHub.</string>
     <string name="accessibility_explainer_privacy_note">Vi verdset din personvern. Scrolless bruker berre denne tillatelsen for å oppdage og stoppe kortforminnhald. Vi samlar ikkje inn personleg informasjon.</string>
     <string name="accessibility_explainer_proceed_button">Gå til Innstillingar</string>
-    <string name="accessibility_explainer_step1">Trykk "Gå til innstillingar" under for å opne Androids tilgjengelegheitsinnstillingar</string>
-    <string name="accessibility_explainer_step2">Finn applikasjonar og trykk på "Scrolless" i lista over tenester</string>
+    <string name="accessibility_explainer_step1">Trykk \"Gå til innstillingar\" under for å opne Androids tilgjengelegheitsinnstillingar</string>
+    <string name="accessibility_explainer_step2">Finn applikasjonar og trykk på \"Scrolless\" i lista over tenester</string>
     <string name="accessibility_explainer_step3">Snu bryteren til PÅ for å aktivere Scrolless til å hjelpe deg med å stoppe endeløs scrolling</string>
     <string name="accessibility_explainer_subtitle">Scrolless treng tilgang til tilgjengelegheit for å oppdage og stoppe korte videoar.</string>
     <string name="accessibility_explainer_title">Vi treng tilgang til tilgjengelegheit</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -9,8 +9,8 @@
     <string name="accessibility_explainer_open_source">Nasz kod jest w 100\% otwartym źródłem na GitHub.</string>
     <string name="accessibility_explainer_privacy_note">Cenimy Twoją prywatność. Scrolless używa tej zgody tylko do wykrywania i zatrzymywania treści w krótkiej formie. Nie zbieramy żadnych danych osobowych.</string>
     <string name="accessibility_explainer_proceed_button">Przejdź do Ustawień</string>
-    <string name="accessibility_explainer_step1">Stuknij "Przejdź do ustawień" poniżej, aby otworzyć ustawienia dostępności Androida</string>
-    <string name="accessibility_explainer_step2">Znajdź aplikacje i stuknij w "Scrolless" na liście usług</string>
+    <string name="accessibility_explainer_step1">Stuknij \"Przejdź do ustawień\" poniżej, aby otworzyć ustawienia dostępności Androida</string>
+    <string name="accessibility_explainer_step2">Znajdź aplikacje i stuknij w \"Scrolless\" na liście usług</string>
     <string name="accessibility_explainer_step3">Przełącz przełącznik na WŁĄCZONE, aby umożliwić Scrolless pomoc w zatrzymaniu nieskończonego przewijania</string>
     <string name="accessibility_explainer_subtitle">Scrolless potrzebuje dostępu do usługi dostępności, aby wykrywać i zatrzymywać krótkie filmy.</string>
     <string name="accessibility_explainer_title">Potrzebujemy dostępu do usługi dostępności</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -9,8 +9,8 @@
     <string name="accessibility_explainer_open_source">Nosso código é 100\% open source no GitHub.</string>
     <string name="accessibility_explainer_privacy_note">Valorizamos sua privacidade. O Scrolless usa esta permissão apenas para detectar e interromper conteúdo em formato curto. Não coletamos nenhuma informação pessoal.</string>
     <string name="accessibility_explainer_proceed_button">Vá para Configurações</string>
-    <string name="accessibility_explainer_step1">Toque em "Ir para Configurações" abaixo para abrir as configurações de Acessibilidade do Android</string>
-    <string name="accessibility_explainer_step2">Encontre aplicativos e toque em "Scrolless" na lista de serviços</string>
+    <string name="accessibility_explainer_step1">Toque em \"Ir para Configurações\" abaixo para abrir as configurações de Acessibilidade do Android</string>
+    <string name="accessibility_explainer_step2">Encontre aplicativos e toque em \"Scrolless\" na lista de serviços</string>
     <string name="accessibility_explainer_step3">Ative o interruptor para habilitar o Scrolless a ajudá-lo a parar o scroll sem fim</string>
     <string name="accessibility_explainer_subtitle">O Scrolless precisa de acesso à acessibilidade para detectar e parar vídeos curtos.</string>
     <string name="accessibility_explainer_title">Precisamos de Acesso à Acessibilidade</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -9,8 +9,8 @@
     <string name="accessibility_explainer_open_source">O nosso código é 100\% open source no GitHub.</string>
     <string name="accessibility_explainer_privacy_note">Valorizamos a sua privacidade. O Scrolless utiliza esta permissão apenas para detetar e parar conteúdo de formato curto. Não recolhemos nenhuma informação pessoal.</string>
     <string name="accessibility_explainer_proceed_button">Ir para Definições</string>
-    <string name="accessibility_explainer_step1">Toque em "Ir para Definições" abaixo para abrir as definições de Acessibilidade do Android</string>
-    <string name="accessibility_explainer_step2">Encontre aplicações e toque em "Scrolless" na lista de serviços</string>
+    <string name="accessibility_explainer_step1">Toque em \"Ir para Definições\" abaixo para abrir as definições de Acessibilidade do Android</string>
+    <string name="accessibility_explainer_step2">Encontre aplicações e toque em \"Scrolless\" na lista de serviços</string>
     <string name="accessibility_explainer_step3">Ative o interruptor para permitir que o Scrolless o ajude a parar o scroll sem fim.</string>
     <string name="accessibility_explainer_subtitle">O Scrolless precisa de acesso à acessibilidade para detetar e parar vídeos curtos.</string>
     <string name="accessibility_explainer_title">Precisamos de Acesso à Acessibilidade</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -9,8 +9,8 @@
     <string name="accessibility_explainer_open_source">Codul nostru este 100\% open source pe GitHub.</string>
     <string name="accessibility_explainer_privacy_note">Apreciem confidențialitatea dumneavoastră. Scrolless folosește această permisiune doar pentru a detecta și opri conținutul de scurtă durată. Nu colectăm nicio informație personală.</string>
     <string name="accessibility_explainer_proceed_button">Mergi la Setări</string>
-    <string name="accessibility_explainer_step1">Apasă "Mergi la Setări" mai jos pentru a deschide setările de Accesibilitate ale Android</string>
-    <string name="accessibility_explainer_step2">Găsește aplicațiile și apasă pe "Scrolless" în lista de servicii</string>
+    <string name="accessibility_explainer_step1">Apasă \"Mergi la Setări\" mai jos pentru a deschide setările de Accesibilitate ale Android</string>
+    <string name="accessibility_explainer_step2">Găsește aplicațiile și apasă pe \"Scrolless\" în lista de servicii</string>
     <string name="accessibility_explainer_step3">Comută întrerupătorul pe ON pentru a activa Scrolless și a te ajuta să oprești derularea fără sfârșit.</string>
     <string name="accessibility_explainer_subtitle">Scrolless are nevoie de acces la servicii de accesibilitate pentru a detecta și opri videoclipurile scurte.</string>
     <string name="accessibility_explainer_title">Avem nevoie de accesibilitate</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -9,8 +9,8 @@
     <string name="accessibility_explainer_open_source">Наш код на 100\% открыт и доступен на GitHub.</string>
     <string name="accessibility_explainer_privacy_note">Мы ценим вашу конфиденциальность. Scrolless использует это разрешение только для обнаружения и остановки короткого контента. Мы не собираем никакую личную информацию.</string>
     <string name="accessibility_explainer_proceed_button">Перейти в настройки</string>
-    <string name="accessibility_explainer_step1">Нажмите "Перейти к настройкам" ниже, чтобы открыть настройки доступности Android</string>
-    <string name="accessibility_explainer_step2">Найдите приложения и нажмите на "Scrolless" в списке служб</string>
+    <string name="accessibility_explainer_step1">Нажмите \"Перейти к настройкам\" ниже, чтобы открыть настройки доступности Android</string>
+    <string name="accessibility_explainer_step2">Найдите приложения и нажмите на \"Scrolless\" в списке служб</string>
     <string name="accessibility_explainer_step3">Переключите тумблер в положение ВКЛ, чтобы включить Scrolless и помочь вам остановить бесконечный скроллинг.</string>
     <string name="accessibility_explainer_subtitle">Scrolless требует доступа к службам доступности для обнаружения и остановки коротких видео.</string>
     <string name="accessibility_explainer_title">Нам нужен доступ к службе доступности</string>

--- a/app/src/main/res/values-sk-rSK/strings.xml
+++ b/app/src/main/res/values-sk-rSK/strings.xml
@@ -9,8 +9,8 @@
     <string name="accessibility_explainer_open_source">Náš kód je 100\% open source na GitHub.</string>
     <string name="accessibility_explainer_privacy_note">Ceníme si vaše súkromie. Scrolless používa toto povolenie iba na detekciu a zastavenie krátkeho obsahu. Nezhromažďujeme žiadne osobné informácie.</string>
     <string name="accessibility_explainer_proceed_button">Prejdite na Nastavenia</string>
-    <string name="accessibility_explainer_step1">Klepnutím na "Prejsť do nastavení" nižšie otvoríte nastavenia prístupnosti systému Android</string>
-    <string name="accessibility_explainer_step2">Nájdite aplikácie a ťuknite na "Scrolless" v zozname služieb</string>
+    <string name="accessibility_explainer_step1">Klepnutím na \"Prejsť do nastavení\" nižšie otvoríte nastavenia prístupnosti systému Android</string>
+    <string name="accessibility_explainer_step2">Nájdite aplikácie a ťuknite na \"Scrolless\" v zozname služieb</string>
     <string name="accessibility_explainer_step3">Prepnite prepínač na ZAPNUTÉ, aby ste povolili Scrolless, ktorý vám pomôže zastaviť nekonečné posúvanie.</string>
     <string name="accessibility_explainer_subtitle">Scrolless potrebuje prístup k prístupnosti, aby mohol detegovať a zastaviť krátke videá.</string>
     <string name="accessibility_explainer_title">Potrebujeme prístup k prístupnosti</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -9,8 +9,8 @@
     <string name="accessibility_explainer_open_source">Naš kod je 100\% otvorenog koda na GitHub-u.</string>
     <string name="accessibility_explainer_privacy_note">Cenimo vašu privatnost. Scrolless koristi ovu dozvolu samo za otkrivanje i zaustavljanje kratkog sadržaja. Ne prikupljamo nikakve lične informacije.</string>
     <string name="accessibility_explainer_proceed_button">Idite na Podešavanja</string>
-    <string name="accessibility_explainer_step1">Dodirnite "Idite na podešavanja" ispod da otvorite Androidove postavke pristupačnosti</string>
-    <string name="accessibility_explainer_step2">Pronađite aplikacije i dodirnite "Scrolless" na listi usluga</string>
+    <string name="accessibility_explainer_step1">Dodirnite \"Idite na podešavanja\" ispod da otvorite Androidove postavke pristupačnosti</string>
+    <string name="accessibility_explainer_step2">Pronađite aplikacije i dodirnite \"Scrolless\" na listi usluga</string>
     <string name="accessibility_explainer_step3">Prebacite prekidač na Uključeno da omogućite Scrolless da vam pomogne da prekinete beskrajno skrolovanje.</string>
     <string name="accessibility_explainer_subtitle">Scrolless zahteva pristup pristupačnosti kako bi otkrio i zaustavio kratke video snimke.</string>
     <string name="accessibility_explainer_title">Potrebna nam je pristupnost</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -9,8 +9,8 @@
     <string name="accessibility_explainer_open_source">Vår kod är 100\% öppen källkod på GitHub.</string>
     <string name="accessibility_explainer_privacy_note">Vi värdesätter din integritet. Scrolless använder endast denna behörighet för att upptäcka och stoppa kortformat innehåll. Vi samlar inte in någon personlig information.</string>
     <string name="accessibility_explainer_proceed_button">Gå till Inställningar</string>
-    <string name="accessibility_explainer_step1">Tryck på "Gå till inställningar" nedan för att öppna Androids tillgänglighetsinställningar</string>
-    <string name="accessibility_explainer_step2">Hitta appar och tryck på "Scrolless" i listan över tjänster</string>
+    <string name="accessibility_explainer_step1">Tryck på \"Gå till inställningar\" nedan för att öppna Androids tillgänglighetsinställningar</string>
+    <string name="accessibility_explainer_step2">Hitta appar och tryck på \"Scrolless\" i listan över tjänster</string>
     <string name="accessibility_explainer_step3">Slå på knappen för att aktivera Scrolless så att du kan sluta med oändligt scrollande</string>
     <string name="accessibility_explainer_subtitle">Scrolless behöver tillgång till tillgänglighet för att upptäcka och stoppa korta videor.</string>
     <string name="accessibility_explainer_title">Vi behöver tillgång till tillgänglighet</string>

--- a/app/src/main/res/values-ta-rIN/strings.xml
+++ b/app/src/main/res/values-ta-rIN/strings.xml
@@ -10,7 +10,7 @@
     <string name="accessibility_explainer_privacy_note">நாங்கள் உங்கள் தனியுரிமையை மதிக்கிறோம். Scrolless இந்த அனுமதியை குறுகிய வடிவ உள்ளடக்கத்தை கண்டறிந்து நிறுத்துவதற்காக மட்டுமே பயன்படுத்துகிறது. நாங்கள் எந்த தனிப்பட்ட தகவலையும் சேகரிக்கவில்லை.</string>
     <string name="accessibility_explainer_proceed_button">அமைப்புகளுக்கு செல்லவும்</string>
     <string name="accessibility_explainer_step1">"கீழே உள்ள \"அமைப்புகளைப் செல்லவும்\" என்பதைத் தொடுங்கள், Android இன் அணுகல் அமைப்புகளை திறக்க."</string>
-    <string name="accessibility_explainer_step2">சேவைகளின் பட்டியலில் "Scrolless" என்பதைக் கண்டறிந்து அதைப் தொட்டு தேர்ந்தெடுக்கவும்.</string>
+    <string name="accessibility_explainer_step2">சேவைகளின் பட்டியலில் \"Scrolless\" என்பதைக் கண்டறிந்து அதைப் தொட்டு தேர்ந்தெடுக்கவும்.</string>
     <string name="accessibility_explainer_step3">ஸ்க்ரோலெஸ் உங்கள் முடிவற்ற ஸ்க்ரோலிங்கை நிறுத்த உதவுவதற்கு ON ஆக மாறியை மாற்றவும்.</string>
     <string name="accessibility_explainer_subtitle">Scrolless குறுகிய வீடியோக்களை கண்டறிந்து நிறுத்த அணுகல் சேவையை தேவைப்படுகிறது.</string>
     <string name="accessibility_explainer_title">எங்களுக்கு அணுகல் சேவையின் அணுகல் தேவை</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -9,8 +9,8 @@
     <string name="accessibility_explainer_open_source">Kodumuz %100 açık kaynak olarak GitHub\'da.</string>
     <string name="accessibility_explainer_privacy_note">Gizliliğinize değer veriyoruz. Scrolless, bu izni yalnızca kısa form içeriklerini tespit etmek ve durdurmak için kullanır. Herhangi bir kişisel bilgi toplamıyoruz.</string>
     <string name="accessibility_explainer_proceed_button">Ayarlar\'a git</string>
-    <string name="accessibility_explainer_step1">Aşağıda "Ayarlar\'a git" butonuna dokunarak Android\'in Erişilebilirlik ayarlarını açın.</string>
-    <string name="accessibility_explainer_step2">Uygulamaları bul ve hizmetler listesindeki "Scrolless"e dokun.</string>
+    <string name="accessibility_explainer_step1">Aşağıda \"Ayarlar\'a git\" butonuna dokunarak Android\'in Erişilebilirlik ayarlarını açın.</string>
+    <string name="accessibility_explainer_step2">Uygulamaları bul ve hizmetler listesindeki \"Scrolless\"e dokun.</string>
     <string name="accessibility_explainer_step3">Scrolless\'in sonsuz kaydırmayı durdurmanıza yardımcı olması için anahtarı AÇIK konuma getirin.</string>
     <string name="accessibility_explainer_subtitle">Scrolless, kısa videoları tespit etmek ve durdurmak için erişilebilirlik erişimine ihtiyaç duyar.</string>
     <string name="accessibility_explainer_title">Erişim İhtiyacımız Var</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -9,8 +9,8 @@
     <string name="accessibility_explainer_open_source">Наш код на 100\% відкритий на GitHub.</string>
     <string name="accessibility_explainer_privacy_note">Ми цінуємо вашу конфіденційність. Scrolless використовує цей дозвіл лише для виявлення та зупинки короткого контенту. Ми не збираємо жодної особистої інформації.</string>
     <string name="accessibility_explainer_proceed_button">Перейти до Налаштувань</string>
-    <string name="accessibility_explainer_step1">Натисніть "Перейти до налаштувань" нижче, щоб відкрити налаштування доступності Android.</string>
-    <string name="accessibility_explainer_step2">Знайдіть програми та натисніть на "Scrolless" у списку служб</string>
+    <string name="accessibility_explainer_step1">Натисніть \"Перейти до налаштувань\" нижче, щоб відкрити налаштування доступності Android.</string>
+    <string name="accessibility_explainer_step2">Знайдіть програми та натисніть на \"Scrolless\" у списку служб</string>
     <string name="accessibility_explainer_step3">Перемкніть перемикач на УВІМКНЕННЯ, щоб активувати Scrolless і допомогти вам зупинити безкінечне прокручування.</string>
     <string name="accessibility_explainer_subtitle">Scrolless потребує доступу до служб доступності, щоб виявляти та зупиняти короткі відео.</string>
     <string name="accessibility_explainer_title">Нам потрібен доступ до служби доступності</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -9,8 +9,8 @@
     <string name="accessibility_explainer_open_source">Mã của chúng tôi hoàn toàn mã nguồn mở trên GitHub.</string>
     <string name="accessibility_explainer_privacy_note">Chúng tôi coi trọng quyền riêng tư của bạn. Scrolless chỉ sử dụng quyền này để phát hiện và ngăn chặn nội dung dạng ngắn. Chúng tôi không thu thập bất kỳ thông tin cá nhân nào.</string>
     <string name="accessibility_explainer_proceed_button">Đi tới Cài đặt</string>
-    <string name="accessibility_explainer_step1">Nhấn "Đi đến Cài đặt" bên dưới để mở cài đặt Truy cập của Android</string>
-    <string name="accessibility_explainer_step2">Tìm ứng dụng và chạm vào "Scrolless" trong danh sách dịch vụ</string>
+    <string name="accessibility_explainer_step1">Nhấn \"Đi đến Cài đặt\" bên dưới để mở cài đặt Truy cập của Android</string>
+    <string name="accessibility_explainer_step2">Tìm ứng dụng và chạm vào \"Scrolless\" trong danh sách dịch vụ</string>
     <string name="accessibility_explainer_step3">Bật công tắc lên để cho phép Scrolless giúp bạn ngừng cuộn không ngừng.</string>
     <string name="accessibility_explainer_subtitle">Scrolless cần quyền truy cập trợ năng để phát hiện và dừng các video ngắn.</string>
     <string name="accessibility_explainer_title">Chúng tôi cần quyền truy cập vào dịch vụ hỗ trợ tiếp cận</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,8 +40,8 @@
     <string name="accessibility_explainer_icon_description">Accessibility Permission Icon</string>
     <string name="accessibility_explainer_title">We Need Accessibility Access</string>
     <string name="accessibility_explainer_subtitle">Scrolless needs accessibility access to detect and stop short videos.</string>
-    <string name="accessibility_explainer_step1">Tap "Go to Settings" below to open Android\'s Accessibility settings</string>
-    <string name="accessibility_explainer_step2">Find applications and tap on "Scrolless" in the list of services</string>
+    <string name="accessibility_explainer_step1">Tap \"Go to Settings\" below to open Android\'s Accessibility settings</string>
+    <string name="accessibility_explainer_step2">Find applications and tap on \"Scrolless\" in the list of services</string>
     <string name="accessibility_explainer_step3">Toggle the switch to ON to enable Scrolless to help you stop endless scrolling</string>
     <string name="accessibility_explainer_privacy_note">We value your privacy. Scrolless only uses this permission to detect and stop short form content. We don\'t collect any personal information.</string>
      <string name="accessibility_explainer_open_source">Our code is 100\% open source on GitHub.</string>


### PR DESCRIPTION
This commit updates the translations of the accessibility explainer steps across multiple languages to use quotation marks around the button text and application name.
- Updated `accessibility_explainer_step1` and `accessibility_explainer_step2` strings in `strings.xml` to include quotation marks.
- The changes were implemented in the following language resource files:
  - `values-vi/strings.xml` (Vietnamese)
  - `values-sv-rSE/strings.xml` (Swedish - Sweden)
  - `values-cs/strings.xml` (Czech)
  - `values-uk-rUA/strings.xml` (Ukrainian - Ukraine)
  - `values-ml/strings.xml` (Malayalam)
  - `values-ru/strings.xml` (Russian)
  - `values-hi/strings.xml` (Hindi)
  - `values-de/strings.xml` (German)
  - `values-nl/strings.xml` (Dutch)
  - `values-ro/strings.xml` (Romanian)
  - `values-el/strings.xml` (Greek)
  - `values-it/strings.xml` (Italian)
  - `values-tr-rTR/strings.xml` (Turkish - Turkey)
  - `values-sr/strings.xml` (Serbian)
  - `values-ca/strings.xml` (Catalan)
  - `values-ta-rIN/strings.xml` (Tamil - India)
  - `values-nn-rNO/strings.xml` (Norwegian Nynorsk - Norway)
  - `values-es/strings.xml` (Spanish)
  - `values-sk-rSK/strings.xml` (Slovak - Slovakia)
  - `values-pt/strings.xml` (Portuguese)
  - `values-fi-rFI/strings.xml` (Finnish - Finland)
  - `values-nb-rNO/strings.xml` (Norwegian Bokmål - Norway)
  - `values/strings.xml` (English)
  - `values-hu/strings.xml` (Hungarian)
  - `values-pt-rBR/strings.xml` (Portuguese - Brazil)
  - `values-b+sr+Latn/strings.xml` (Serbian (Latin))
  - `values-pl/strings.xml` (Polish)
  - `values-fr/strings.xml` (French)
  - `values-hr/strings.xml` (Croatian)