### PR TITLE
feat: Implement in-app review functionality

### DIFF
--- a/app/src/main/kotlin/com/scrolless/app/app/ScrollessAppConfig.kt
+++ b/app/src/main/kotlin/com/scrolless/app/app/ScrollessAppConfig.kt
@@ -4,6 +4,7 @@
  */
 package com.scrolless.app.app
 
+import android.content.Context
 import com.scrolless.app.BuildConfig
 import com.scrolless.app.features.main.MainActivity
 import com.scrolless.framework.core.base.application.CoreConfig
@@ -26,4 +27,14 @@ class ScrollessAppConfig : CoreConfig() {
     override fun uncaughtExceptionPage(): Class<*> = MainActivity::class.java
 
     override fun uncaughtExceptionMessage(): String = "Unknown Error"
+
+    override fun getPlayStoreUrl(context: Context): String {
+        // Get app namespace
+        val packageName = context.packageName
+        val baseNamespace = packageName
+            .replace(".dev", "")
+            .replace(".debug", "")
+
+        return "https://play.google.com/store/apps/details?id=$baseNamespace"
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ junit = "4.13.2"
 androidxJUnit = "1.2.1"
 espressoCore = "3.6.1"
 material = "1.12.0"
+review = "2.0.2"
 paging = "3.3.6"
 workmanager = "2.10.0"
 
@@ -70,6 +71,10 @@ androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = 
 # AppCompat and Material Design
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+
+# Review Library
+android-review = { group = "com.google.android.play", name = "review", version.ref = "review" }
+android-review-ktx = { group = "com.google.android.play", name = "review-ktx", version.ref = "review" }
 
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 androidx-recyclerview = { group = "androidx.recyclerview", name = "recyclerview", version.ref = "recyclerview" }

--- a/libraries/framework/src/main/kotlin/com/scrolless/framework/core/base/application/CoreConfig.kt
+++ b/libraries/framework/src/main/kotlin/com/scrolless/framework/core/base/application/CoreConfig.kt
@@ -4,6 +4,8 @@
  */
 package com.scrolless.framework.core.base.application
 
+import android.content.Context
+
 abstract class CoreConfig {
     abstract fun appName(): String
 
@@ -16,4 +18,6 @@ abstract class CoreConfig {
     open fun uncaughtExceptionPage(): Class<*>? = null
 
     open fun uncaughtExceptionMessage(): String? = null
+
+    open fun getPlayStoreUrl(context: Context): String? = null
 }


### PR DESCRIPTION
This commit introduces the ability for users to rate the app directly from the HomeFragment.

- Added a "Rate Scrolless" button to the HomeFragment layout.
- Implemented a click listener for the "Rate Scrolless" button that triggers the in-app review flow.
- The in-app review flow is implemented using the Play Core In-App Review library.
- If the app is in development mode, clicking the button will open the app's page on the Play Store instead of showing the in-app review dialog.
- If the in-app review request fails, the app will fall back to opening the Play Store page.
- Added the Play Core In-App Review library as a dependency in the project's `libs.versions.toml` file.
- Added `getPlayStoreUrl` to `CoreConfig` to get the app's Play Store URL.
- `ScrollessAppConfig` overrides `getPlayStoreUrl` to return the correct URL based on the app's package name.