### PR TITLE
Fix: Cancel animations when view is destroyed

### DIFF
--- a/app/src/main/kotlin/com/scrolless/app/features/home/HomeFragment.kt
+++ b/app/src/main/kotlin/com/scrolless/app/features/home/HomeFragment.kt
@@ -65,6 +65,10 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
     @Inject
     lateinit var appConfig: CoreConfig
 
+    private var progressAnimator: ValueAnimator? = null
+
+    private var backgroundAnimation: AnimationDrawable? = null
+
     override fun onViewReady(bundle: Bundle?) {
         val rootView = binding.root
         ViewCompat.setOnApplyWindowInsetsListener(rootView) { v, insets ->
@@ -312,8 +316,14 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
      */
 
     private fun animateProgressTo(targetProgress: Int, duration: Long = 1000) {
+        // Cancel any existing animation
+        progressAnimator?.cancel()
+
+        // Create a new animator
         val startProgress = lastProgress
         val valueAnimator = ValueAnimator.ofInt(startProgress, targetProgress)
+        progressAnimator = valueAnimator
+
         valueAnimator.apply {
             this.duration = duration
             interpolator = AccelerateDecelerateInterpolator()
@@ -391,10 +401,12 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
      */
     private fun startGradientAnimation() {
         val layout = binding.layout
-        val animationDrawable = layout.background as AnimationDrawable
-        animationDrawable.setEnterFadeDuration(6000)
-        animationDrawable.setExitFadeDuration(2000)
-        animationDrawable.start()
+        backgroundAnimation = layout.background as AnimationDrawable
+        backgroundAnimation?.apply {
+            setEnterFadeDuration(6000)
+            setExitFadeDuration(2000)
+            start()
+        }
     }
 
     /**
@@ -413,6 +425,14 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
 
     override fun onResume() {
         super.onResume()
+
+        backgroundAnimation?.start()
+    }
+
+    override fun onPause() {
+        super.onPause()
+
+        backgroundAnimation?.stop()
     }
 
     /**
@@ -467,6 +487,15 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
     }
 
     override fun onDestroyView() {
+        // Cancel the progress animator if it's running
+        progressAnimator?.removeAllUpdateListeners()
+        progressAnimator?.cancel()
+        progressAnimator = null
+
+        // Stop the background animation if it's running
+        backgroundAnimation?.stop()
+        backgroundAnimation = null
+
         super.onDestroyView()
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -140,7 +140,6 @@ test-core-testing = { group = "androidx.arch.core", name = "core-testing", versi
 
 moshi-kotlin = { group = "com.squareup.moshi", name = "moshi-kotlin", version.ref = "moshi" }
 
-androidx-viewbinding = { group = "androidx.databinding", name = "viewbinding", version.ref = "viewbinding" }
 androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "preferenceKtx" }
 androidx-preference = { group = "androidx.preference", name = "preference", version.ref = "preference" }
 


### PR DESCRIPTION
This pull request includes changes to the `HomeFragment` class in `app/src/main/kotlin/com/scrolless/app/features/home/HomeFragment.kt` to add animations and improve resource cleanup. Additionally, it includes a minor change to the `gradle/libs.versions.toml` file.

The most important changes include adding progress and background animations, ensuring proper cleanup of resources, and a minor dependency update.

### Animations and Resource Cleanup:

* Added `progressAnimator` and `backgroundAnimation` variables to manage animations in the `HomeFragment` class.
* Enhanced the `animateProgressTo` method to cancel any existing animation before starting a new one and assign the new animator to `progressAnimator`.
* Updated the `startGradientAnimation` method to use `backgroundAnimation` and apply fade durations before starting the animation.
* Added `onResume` and `onPause` lifecycle methods to start and stop the `backgroundAnimation` respectively.
* Ensured proper cleanup in the `onDestroyView` method by canceling and nullifying `progressAnimator` and stopping and nullifying `backgroundAnimation`.

### Dependency Update:

* Removed the `androidx-viewbinding` dependency from `gradle/libs.versions.toml`.