### PR TITLE
feat: If accessibility permission is lost, notify user on reopen

### DIFF
--- a/app/src/main/kotlin/com/scrolless/app/features/home/HomeFragment.kt
+++ b/app/src/main/kotlin/com/scrolless/app/features/home/HomeFragment.kt
@@ -604,7 +604,6 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
      * Unregisters the broadcast receiver that opens the app after enabling accessibility service.
      */
     private fun unregisterBroadcastReceiver() {
-
         // Unregister receiver
         context?.let { ctx ->
 

--- a/app/src/main/kotlin/com/scrolless/app/features/home/HomeFragment.kt
+++ b/app/src/main/kotlin/com/scrolless/app/features/home/HomeFragment.kt
@@ -595,6 +595,16 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
         backgroundAnimation?.stop()
         backgroundAnimation = null
 
+        // Unregister the Accessibility enabled permission
+        unregisterBroadcastReceiver()
+        super.onDestroyView()
+    }
+
+    /**
+     * Unregisters the broadcast receiver that opens the app after enabling accessibility service.
+     */
+    private fun unregisterBroadcastReceiver() {
+
         // Unregister receiver
         context?.let { ctx ->
 
@@ -613,7 +623,6 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
         }
 
         serviceEnabledReceiver = null // Clear reference
-        super.onDestroyView()
     }
 
     /**
@@ -643,15 +652,22 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
      */
     private fun updateUIForBlockOption(blockOption: BlockOption) {
         resetButtons()
-        when (blockOption) {
-            BlockOption.BlockAll -> applyButtonEffect(binding.blockAllButton, true)
-            BlockOption.DailyLimit -> {
-                binding.configDailyLimitButton.visibility = View.VISIBLE
-                applyButtonEffect(binding.dailyLimitButton, true)
-            }
 
-            BlockOption.IntervalTimer -> applyButtonEffect(binding.intervalTimerButton, true)
-            BlockOption.NothingSelected -> Unit // No action needed
+        if (blockOption == BlockOption.NothingSelected) {
+            return
+        }
+        safeguardedAction {
+            @Suppress("KotlinConstantConditions")
+            when (blockOption) {
+                BlockOption.BlockAll -> applyButtonEffect(binding.blockAllButton, true)
+                BlockOption.DailyLimit -> {
+                    binding.configDailyLimitButton.visibility = View.VISIBLE
+                    applyButtonEffect(binding.dailyLimitButton, true)
+                }
+
+                BlockOption.IntervalTimer -> applyButtonEffect(binding.intervalTimerButton, true)
+                BlockOption.NothingSelected -> Unit // No action needed
+            }
         }
     }
 


### PR DESCRIPTION
This pull request introduces improvements to the `HomeFragment` class in the `Scrolless` app, focusing on better lifecycle management and UI updates for specific user interactions. The key changes include properly unregistering a broadcast receiver during the fragment's destruction and refining the logic for handling UI updates based on user-selected options.

### Lifecycle Management Enhancements:
* Added `unregisterBroadcastReceiver()` method to ensure the broadcast receiver is properly unregistered when the fragment's view is destroyed, preventing potential memory leaks. The `super.onDestroyView()` call was moved to follow this cleanup. [[1]](diffhunk://#diff-b8c0b57331b6808a22c0406482e1018ee9ef7d37a80b3d9a3b2b0bee61246783R598-R607) [[2]](diffhunk://#diff-b8c0b57331b6808a22c0406482e1018ee9ef7d37a80b3d9a3b2b0bee61246783L616)

### UI Update Improvements:
* Updated the `updateUIForBlockOption` method to include an early return when the `NothingSelected` option is chosen, avoiding unnecessary UI updates. [[1]](diffhunk://#diff-b8c0b57331b6808a22c0406482e1018ee9ef7d37a80b3d9a3b2b0bee61246783R655-R660) [[2]](diffhunk://#diff-b8c0b57331b6808a22c0406482e1018ee9ef7d37a80b3d9a3b2b0bee61246783R672)