### PR TITLE
feat: Refactor blocked content entry handling in accessibility service

### DIFF
--- a/app/src/main/kotlin/com/scrolless/app/features/home/HomeFragment.kt
+++ b/app/src/main/kotlin/com/scrolless/app/features/home/HomeFragment.kt
@@ -595,6 +595,15 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
         backgroundAnimation?.stop()
         backgroundAnimation = null
 
+        // Unregister the Accessibility enabled permission
+        unregisterBroadcastReceiver()
+        super.onDestroyView()
+    }
+
+    /**
+     * Unregisters the broadcast receiver that opens the app after enabling accessibility service.
+     */
+    private fun unregisterBroadcastReceiver() {
         // Unregister receiver
         context?.let { ctx ->
 
@@ -613,7 +622,6 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
         }
 
         serviceEnabledReceiver = null // Clear reference
-        super.onDestroyView()
     }
 
     /**
@@ -643,15 +651,22 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
      */
     private fun updateUIForBlockOption(blockOption: BlockOption) {
         resetButtons()
-        when (blockOption) {
-            BlockOption.BlockAll -> applyButtonEffect(binding.blockAllButton, true)
-            BlockOption.DailyLimit -> {
-                binding.configDailyLimitButton.visibility = View.VISIBLE
-                applyButtonEffect(binding.dailyLimitButton, true)
-            }
 
-            BlockOption.IntervalTimer -> applyButtonEffect(binding.intervalTimerButton, true)
-            BlockOption.NothingSelected -> Unit // No action needed
+        if (blockOption == BlockOption.NothingSelected) {
+            return
+        }
+        safeguardedAction {
+            @Suppress("KotlinConstantConditions")
+            when (blockOption) {
+                BlockOption.BlockAll -> applyButtonEffect(binding.blockAllButton, true)
+                BlockOption.DailyLimit -> {
+                    binding.configDailyLimitButton.visibility = View.VISIBLE
+                    applyButtonEffect(binding.dailyLimitButton, true)
+                }
+
+                BlockOption.IntervalTimer -> applyButtonEffect(binding.intervalTimerButton, true)
+                BlockOption.NothingSelected -> Unit // No action needed
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/scrolless/app/services/ScrollessBlockAccessibilityService.kt
+++ b/app/src/main/kotlin/com/scrolless/app/services/ScrollessBlockAccessibilityService.kt
@@ -5,7 +5,6 @@
 package com.scrolless.app.services
 
 import android.accessibilityservice.AccessibilityService
-import android.accessibilityservice.AccessibilityService.GLOBAL_ACTION_BACK
 import android.accessibilityservice.AccessibilityServiceInfo
 import android.content.Intent
 import android.os.Handler
@@ -54,7 +53,7 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
     @Inject
     lateinit var timerOverlayManager: TimerOverlayManager
 
-    private var currentOnVideos = false
+    private var isProcessingBlockedContent = false
     private var timeStartOnBrainRot: Long = 0L
 
     private val blockedViews = setOf(
@@ -65,7 +64,7 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
 
     private val videoCheckRunnable = object : Runnable {
         override fun run() {
-            if (currentOnVideos) {
+            if (isProcessingBlockedContent) {
                 val elapsed = System.currentTimeMillis() - timeStartOnBrainRot
                 if (blockController.onPeriodicCheck(elapsed)) {
                     performBackNavigation()
@@ -143,11 +142,11 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
 
     private fun onBlockedContentEntered() {
         // If the currentOnVideos boolean is set to true, we already dealt with the event
-        if (currentOnVideos) {
+        if (isProcessingBlockedContent) {
             return
         }
 
-        currentOnVideos = true
+        isProcessingBlockedContent = true
         timeStartOnBrainRot = System.currentTimeMillis()
         startPeriodicCheck()
 
@@ -165,7 +164,7 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
     }
 
     private fun onBlockedContentExited() {
-        if (currentOnVideos) {
+        if (isProcessingBlockedContent) {
             val sessionTime = System.currentTimeMillis() - timeStartOnBrainRot
 
             // Add to usage in memory
@@ -174,7 +173,7 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
             // Let block controller do its logic, if needed
             blockController.onExitBlockedContent(sessionTime)
 
-            currentOnVideos = false
+            isProcessingBlockedContent = false
             stopPeriodicCheck()
 
             if (appProvider.timerOverlayEnabled) {


### PR DESCRIPTION
This commit tracks the usage time (in short videos) even if no option is selected

-   Removed the unused `active` variable.
This pull request refactors the `ScrollessBlockAccessibilityService` class to simplify the logic and improve readability by removing the `active` property and reorganizing the `onBlockedContentEntered` method.

### Simplification of state management:

* Removed the `active` property and all associated logic, as it was no longer necessary for controlling the service's behavior. (`ScrollessBlockAccessibilityService.kt`: [[1]](diffhunk://#diff-ecbca720bf3ba0428be35ef6c9b9cf6fe9239374c5fe1f4df18fc61ffb29c92fL57) [[2]](diffhunk://#diff-ecbca720bf3ba0428be35ef6c9b9cf6fe9239374c5fe1f4df18fc61ffb29c92fL96) [[3]](diffhunk://#diff-ecbca720bf3ba0428be35ef6c9b9cf6fe9239374c5fe1f4df18fc61ffb29c92fL105)

### Improvements to `onBlockedContentEntered` logic:

* Refactored the `onBlockedContentEntered` method to simplify its flow:
  - Added an early return if `currentOnVideos` is `true`, avoiding redundant processing.
  - Reorganized the timer overlay logic and daily reset check for better clarity and separation of concerns. (`ScrollessBlockAccessibilityService.kt`: [app/src/main/kotlin/com/scrolless/app/services/ScrollessBlockAccessibilityService.ktL148-L165](diffhunk://#diff-ecbca720bf3ba0428be35ef6c9b9cf6fe9239374c5fe1f4df18fc61ffb29c92fL148-L165))