### PR TITLE
fix(review): Correct Play Store link for debug builds

### DIFF
--- a/mobile/src/main/java/com/scrolless/app/util/ReviewUtils.kt
+++ b/mobile/src/main/java/com/scrolless/app/util/ReviewUtils.kt
@@ -28,7 +28,7 @@ fun requestAppReview(activity: Activity) {
 
     if (BuildConfig.DEBUG) {
         // Skip in-app review in debug builds
-        openPlayStore(activity, activity.packageName.replace(".debug", ""))
+        openPlayStore(activity, activity.packageName.removeSuffix(".debug"))
         return
     }
 


### PR DESCRIPTION
This commit fixes the in-app review flow for debug builds.

Previously, the "Rate App" button would fail to open the Play Store page because it was using the debug package name, which includes the `.debug` suffix (e.g., `com.scrolless.app.debug`). The Play Store does not have a listing for this package name.

The fix removes the `.debug` suffix from the package name before constructing the Play Store URL, ensuring that the link correctly points to the production app listing even when triggered from a debug version.