### PR TITLE
Feat: Show explainer when timer overlay is enabled and accessibility is disabled

### DIFF
--- a/mobile/build.gradle.kts
+++ b/mobile/build.gradle.kts
@@ -56,8 +56,8 @@ android {
             libs.versions.targetSdk
                 .get()
                 .toInt()
-        versionCode = 6
-        versionName = "0.6.0"
+        versionCode = 7
+        versionName = "0.7.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/mobile/src/main/java/com/scrolless/app/ui/home/HomeScreen.kt
+++ b/mobile/src/main/java/com/scrolless/app/ui/home/HomeScreen.kt
@@ -218,6 +218,11 @@ fun HomeScreen(modifier: Modifier = Modifier, viewModel: HomeViewModel = hiltVie
                     Timber.i("Block option selected while accessibility disabled - showing explainer")
                     showAccessibilityExplainerPrompt(setWaitingForAccessibility = false)
                 }
+
+                uiState.timerOverlayEnabled -> {
+                    Timber.i("Timer overlay ON while accessibility disabled - showing explainer")
+                    showAccessibilityExplainerPrompt(setWaitingForAccessibility = false)
+                }
             }
         }
     }


### PR DESCRIPTION
This is to avoid users seeing the timer overlay option on and not seeing it because the accessibility is off