### PR TITLE
fix: Improve Facebook detection with multiple content description methods

### DIFF
--- a/core/domain/src/main/java/com/scrolless/app/core/model/BlockableApp.kt
+++ b/core/domain/src/main/java/com/scrolless/app/core/model/BlockableApp.kt
@@ -88,12 +88,12 @@ enum class BlockableApp(
     ),
     FACEBOOK(
         packageMatchers = listOf(PackageMatcher.Exact("com.facebook.katana")),
-        // Facebook needs several detection methods as there's different ways of watching reels
+        // Facebook needs several detection methods because there's different ways of watching reels
         // 1. By pressing on a reel in the main feed
-        //      - Easy detection by the content description Sticker & GIF
-        // 2- By pressing the Reels tab
-        //      - We need to see if there's "Reels" and "Tab" in the content description
-        //      - The reason for not just "reels" we need to discard any text that just says Reels that can appear on the feed
+        //      - Easy detection by the content descriptions Sticker & GIF
+        // 2. By pressing the Reels tab
+        //      - Here we expect the selected top navigation accessibility label to start with "Reels, tab"
+        //      - The reason for not just matching "Reels" is that this text can also appear in the user feed
         detectionMethod = DetectionMethod.AnyOf(
             listOf(
                 DetectionMethod.ContentDescriptions(

--- a/core/domain/src/main/java/com/scrolless/app/core/model/BlockableApp.kt
+++ b/core/domain/src/main/java/com/scrolless/app/core/model/BlockableApp.kt
@@ -26,6 +26,12 @@ import androidx.compose.runtime.Immutable
 sealed class DetectionMethod {
     data class ViewId(val viewId: String) : DetectionMethod()
     data class ContentDescriptions(val contentDescriptions: Set<String>) : DetectionMethod()
+    data class ContentDescriptionPrefix(
+        val prefixes: Set<String>,
+        val requireSelected: Boolean = false,
+        val maxTopScreenFraction: Float? = null,
+    ) : DetectionMethod()
+    data class AnyOf(val detectionMethods: List<DetectionMethod>) : DetectionMethod()
 }
 
 // PackageMatcher the information to recognize supported app package variants
@@ -63,9 +69,9 @@ enum class BlockableApp(
     ),
     SHORTS(
         packageMatchers = listOf(
-            PackageMatcher.Prefix("com.google.android.youtube"), // should match YouTube kids and other variants
+            PackageMatcher.Prefix("com.google.android.youtube"),
             PackageMatcher.Exact("com.google.android.apps.youtube.kids"),
-            PackageMatcher.Suffix(".android.youtube"),
+            PackageMatcher.Suffix(".android.youtube"), // should match YouTube and other variants
         ),
         detectionMethod = DetectionMethod.ViewId("reel_player_page_container"),
         exitStrategy = GLOBAL_ACTION_BACK,
@@ -82,11 +88,27 @@ enum class BlockableApp(
     ),
     FACEBOOK(
         packageMatchers = listOf(PackageMatcher.Exact("com.facebook.katana")),
-        detectionMethod = DetectionMethod.ContentDescriptions(
-            setOf(
-                "FbShortsComposerAttachmentComponentSpec_STICKER",
-                "FbShortsComposerAttachmentComponentSpec_GIF",
-                "Reels",
+        // Facebook needs several detection methods as there's different ways of watching reels
+        // 1. By pressing on a reel in the main feed
+        //      - Easy detection by the content description Sticker & GIF
+        // 2- By pressing the Reels tab
+        //      - We need to see if there's "Reels" and "Tab" in the content description
+        //      - The reason for not just "reels" we need to discard any text that just says Reels that can appear on the feed
+        detectionMethod = DetectionMethod.AnyOf(
+            listOf(
+                DetectionMethod.ContentDescriptions(
+                    setOf(
+                        "FbShortsComposerAttachmentComponentSpec_STICKER",
+                        "FbShortsComposerAttachmentComponentSpec_GIF",
+                    ),
+                ),
+                // Facebook also shows feed shelves labeled just "Reels", which should not trigger blocking.
+                // so we search for the accessibility label to start with "Reels, tab" (for example "Reels, tab 2 of 6").
+                DetectionMethod.ContentDescriptionPrefix(
+                    prefixes = setOf("Reels, tab"),
+                    requireSelected = true,
+                    maxTopScreenFraction = 0.2f,
+                ),
             ),
         ),
         exitStrategy = GLOBAL_ACTION_BACK,

--- a/mobile/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
+++ b/mobile/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
@@ -735,21 +735,9 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
      * and look for a matching node
      */
     private fun AccessibilityNodeInfo.hasVisibleContentDescription(contentDescriptions: Set<String>): Boolean {
-        val nodesToVisit = ArrayDeque<AccessibilityNodeInfo>()
-        nodesToVisit.add(this)
-
-        while (nodesToVisit.isNotEmpty()) {
-            val node = nodesToVisit.removeFirst()
-            if (isNodeVisibleToTheUser(node) && node.contentDescription?.toString() in contentDescriptions) {
-                return true
-            }
-
-            for (index in 0 until node.childCount) {
-                node.getChild(index)?.let(nodesToVisit::addLast)
-            }
+        return hasVisibleNodeMatching { node ->
+            node.contentDescription?.toString() in contentDescriptions
         }
-
-        return false
     }
 
     /**
@@ -761,23 +749,32 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
     ): Boolean {
         val rootBounds = android.graphics.Rect().also(::getBoundsInScreen)
         val maxTop = detectionMethod.maxTopScreenFraction?.let { fraction ->
-            rootBounds.top + (rootBounds.height() * fraction).toInt()
+            val clampedFraction = fraction.coerceIn(0f, 1f)
+            rootBounds.top + (rootBounds.height() * clampedFraction).toInt()
         }
+
+        return hasVisibleNodeMatching { node ->
+            val contentDescription = node.contentDescription?.toString() ?: return@hasVisibleNodeMatching false
+            val matchesPrefix = detectionMethod.prefixes.any(contentDescription::startsWith)
+            if (!matchesPrefix) {
+                return@hasVisibleNodeMatching false
+            }
+
+            val nodeBounds = android.graphics.Rect().also(node::getBoundsInScreen)
+            val matchesSelectedState = !detectionMethod.requireSelected || node.isSelected
+            val matchesTopConstraint = maxTop == null || nodeBounds.bottom <= maxTop
+            matchesSelectedState && matchesTopConstraint
+        }
+    }
+
+    private fun AccessibilityNodeInfo.hasVisibleNodeMatching(matchesNode: (AccessibilityNodeInfo) -> Boolean): Boolean {
         val nodesToVisit = ArrayDeque<AccessibilityNodeInfo>()
         nodesToVisit.add(this)
 
         while (nodesToVisit.isNotEmpty()) {
             val node = nodesToVisit.removeFirst()
-            val contentDescription = node.contentDescription?.toString()
-            val matchesPrefix = contentDescription != null &&
-                detectionMethod.prefixes.any(contentDescription::startsWith)
-            if (matchesPrefix && isNodeVisibleToTheUser(node)) {
-                val nodeBounds = android.graphics.Rect().also(node::getBoundsInScreen)
-                val matchesSelectedState = !detectionMethod.requireSelected || node.isSelected
-                val matchesTopConstraint = maxTop == null || nodeBounds.bottom <= maxTop
-                if (matchesSelectedState && matchesTopConstraint) {
-                    return true
-                }
+            if (isNodeVisibleToTheUser(node) && matchesNode(node)) {
+                return true
             }
 
             for (index in 0 until node.childCount) {

--- a/mobile/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
+++ b/mobile/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
@@ -708,13 +708,25 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
      * to support both signals here.
      */
     private fun AccessibilityNodeInfo.matchesBlockedContent(blockableApp: ResolvedBlockableApp): Boolean {
+        return matchesDetectionMethod(blockableApp, blockableApp.getDetectionMethod())
+    }
 
-        return when (val detectionMethod = blockableApp.getDetectionMethod()) {
+    private fun AccessibilityNodeInfo.matchesDetectionMethod(
+        blockableApp: ResolvedBlockableApp,
+        detectionMethod: DetectionMethod,
+    ): Boolean {
+        return when (detectionMethod) {
             is DetectionMethod.ViewId ->
                 findAccessibilityNodeInfosByViewId(blockableApp.getViewId(detectionMethod)).any(::isNodeVisibleToTheUser)
 
             is DetectionMethod.ContentDescriptions ->
                 hasVisibleContentDescription(detectionMethod.contentDescriptions)
+
+            is DetectionMethod.ContentDescriptionPrefix ->
+                hasVisibleContentDescriptionPrefix(detectionMethod)
+
+            is DetectionMethod.AnyOf ->
+                detectionMethod.detectionMethods.any { matchesDetectionMethod(blockableApp, it) }
         }
     }
 
@@ -730,6 +742,42 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
             val node = nodesToVisit.removeFirst()
             if (isNodeVisibleToTheUser(node) && node.contentDescription?.toString() in contentDescriptions) {
                 return true
+            }
+
+            for (index in 0 until node.childCount) {
+                node.getChild(index)?.let(nodesToVisit::addLast)
+            }
+        }
+
+        return false
+    }
+
+    /**
+     * Prefix matching for content descriptions lets us target stable navigation labels such as
+     * "Reels, tab 2 of 6" without treating every visible "Reels" label in the feed as a block trigger.
+     */
+    private fun AccessibilityNodeInfo.hasVisibleContentDescriptionPrefix(
+        detectionMethod: DetectionMethod.ContentDescriptionPrefix,
+    ): Boolean {
+        val rootBounds = android.graphics.Rect().also(::getBoundsInScreen)
+        val maxTop = detectionMethod.maxTopScreenFraction?.let { fraction ->
+            rootBounds.top + (rootBounds.height() * fraction).toInt()
+        }
+        val nodesToVisit = ArrayDeque<AccessibilityNodeInfo>()
+        nodesToVisit.add(this)
+
+        while (nodesToVisit.isNotEmpty()) {
+            val node = nodesToVisit.removeFirst()
+            val contentDescription = node.contentDescription?.toString()
+            val matchesPrefix = contentDescription != null &&
+                detectionMethod.prefixes.any(contentDescription::startsWith)
+            if (matchesPrefix && isNodeVisibleToTheUser(node)) {
+                val nodeBounds = android.graphics.Rect().also(node::getBoundsInScreen)
+                val matchesSelectedState = !detectionMethod.requireSelected || node.isSelected
+                val matchesTopConstraint = maxTop == null || nodeBounds.bottom <= maxTop
+                if (matchesSelectedState && matchesTopConstraint) {
+                    return true
+                }
             }
 
             for (index in 0 until node.childCount) {


### PR DESCRIPTION
The current detection method is too broad and is detecting posts that contain the text "Feed"

This pull request enhances the detection logic for blocking Facebook Reels and similar content by introducing more flexible and robust detection methods. The main improvements are the addition of new detection strategies, especially for handling Facebook's diverse UI patterns, and the implementation of prefix-based content description matching.

**Detection method enhancements:**

* Added `ContentDescriptionPrefix` and `AnyOf` detection methods to the `DetectionMethod` sealed class, allowing for prefix-based matching and combining multiple detection strategies.
* Updated the `FACEBOOK` entry in `BlockableApp` to use the new `AnyOf` detection method, combining both exact and prefix-based content description matching for more accurate detection of Reels.

**Detection logic implementation:**

* Refactored detection logic in `ScrollessBlockAccessibilityService` to support the new detection methods, including recursive matching for `AnyOf` and prefix matching for `ContentDescriptionPrefix`.
* Implemented the `hasVisibleContentDescriptionPrefix` function to perform prefix-based matching with optional constraints on selection state and screen position, improving precision for cases like Facebook's "Reels, tab" navigation.

**Documentation and clarity:**

* Added detailed comments explaining the rationale for the new detection logic, especially for handling Facebook's multiple entry points to Reels and avoiding false positives.

These changes collectively make content blocking more robust and adaptable to UI variations across supported apps.