### PR TITLE
refactor: Simplify BlockingManager initialization and improve accessibility service integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,4 @@ Scrolless app architecture is inspired by the Google open source project [Jetcas
 
 Some icons used in this app are obtained from [Icons8](https://icons8.com).
 
-## Star History
-
 [![Star History Chart](https://api.star-history.com/svg?repos=DuarteBarbosaDev/Scrolless&type=Date)](https://star-history.com/#DuarteBarbosaPT/Scrolless&Date)

--- a/core/domain/src/main/java/com/scrolless/app/core/blocking/BlockingManager.kt
+++ b/core/domain/src/main/java/com/scrolless/app/core/blocking/BlockingManager.kt
@@ -26,7 +26,7 @@ interface BlockingManager {
     /**
      * Initializes the manager and starts observing blocking configuration changes.
      */
-    suspend fun init()
+    fun init()
 
     /**
      * Called when entering blocked content.

--- a/core/domain/src/main/java/com/scrolless/app/core/blocking/BlockingManager.kt
+++ b/core/domain/src/main/java/com/scrolless/app/core/blocking/BlockingManager.kt
@@ -16,7 +16,6 @@
  */
 package com.scrolless.app.core.blocking
 
-import com.scrolless.app.core.model.BlockOption
 import com.scrolless.app.core.model.BlockingResult
 
 /**
@@ -25,11 +24,9 @@ import com.scrolless.app.core.model.BlockingResult
 interface BlockingManager {
 
     /**
-     * Initializes the manager with a block option configuration.
-     *
-     * @param blockOption The blocking option to apply.
+     * Initializes the manager and starts observing blocking configuration changes.
      */
-    suspend fun init(blockOption: BlockOption)
+    suspend fun init()
 
     /**
      * Called when entering blocked content.

--- a/core/domain/src/main/java/com/scrolless/app/core/blocking/BlockingManagerImpl.kt
+++ b/core/domain/src/main/java/com/scrolless/app/core/blocking/BlockingManagerImpl.kt
@@ -32,7 +32,8 @@ import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -49,31 +50,43 @@ class BlockingManagerImpl @Inject constructor(
     private val timeProvider: TimeProvider,
 ) : BlockingManager {
 
-    private lateinit var handler: BlockOptionHandler
+    @Volatile
+    private var handler: BlockOptionHandler = NoBlockHandler()
     private val persistenceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     /**
      * Initializes the manager with a block option configuration.
      * Sets up the appropriate handler and ensures usage data is current.
-     *
-     * @param blockOption The blocking option to apply.
      */
-    override suspend fun init(blockOption: BlockOption) {
-        val timeLimit = userSettingsStore.getTimeLimit().first()
-        val intervalLength = userSettingsStore.getIntervalLength().first()
-        val intervalState = IntervalTimerState(
-            windowStartMillis = userSettingsStore.getIntervalWindowStart().first(),
-            usageMillis = userSettingsStore.getIntervalUsage().first(),
-        )
-
-        Timber.i(
-            "init: option=%s, timeLimit=%d, intervalLength=%d, intervalState=%s",
-            blockOption,
-            timeLimit,
-            intervalLength,
-            intervalState,
-        )
-        handler = createHandlerForConfig(blockOption, timeLimit, intervalLength, intervalState)
+    override suspend fun init() {
+        combine(
+            userSettingsStore.getActiveBlockOption().distinctUntilChanged(),
+            userSettingsStore.getTimeLimit().distinctUntilChanged(),
+            userSettingsStore.getIntervalLength().distinctUntilChanged(),
+            userSettingsStore.getIntervalWindowStart().distinctUntilChanged(),
+            userSettingsStore.getIntervalUsage().distinctUntilChanged(),
+        ) { blockOption, timeLimit, intervalLength, intervalWindowStart, intervalUsage ->
+            val intervalState = IntervalTimerState(
+                windowStartMillis = intervalWindowStart,
+                usageMillis = intervalUsage,
+            )
+            Timber.i(
+                "Initializing blocking manager with: option=%s, timeLimit=%d, intervalLength=%d, intervalState=%s",
+                blockOption,
+                timeLimit,
+                intervalLength,
+                intervalState,
+            )
+            createHandlerForConfig(
+                blockOption,
+                timeLimit,
+                intervalLength,
+                intervalState,
+            )
+        }
+            .collect { newHandler ->
+                handler = newHandler
+            }
     }
 
     /**

--- a/core/domain/src/main/java/com/scrolless/app/core/blocking/BlockingManagerImpl.kt
+++ b/core/domain/src/main/java/com/scrolless/app/core/blocking/BlockingManagerImpl.kt
@@ -52,41 +52,43 @@ class BlockingManagerImpl @Inject constructor(
 
     @Volatile
     private var handler: BlockOptionHandler = NoBlockHandler()
-    private val persistenceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val serviceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     /**
      * Initializes the manager with a block option configuration.
      * Sets up the appropriate handler and ensures usage data is current.
      */
-    override suspend fun init() {
-        combine(
-            userSettingsStore.getActiveBlockOption().distinctUntilChanged(),
-            userSettingsStore.getTimeLimit().distinctUntilChanged(),
-            userSettingsStore.getIntervalLength().distinctUntilChanged(),
-            userSettingsStore.getIntervalWindowStart().distinctUntilChanged(),
-            userSettingsStore.getIntervalUsage().distinctUntilChanged(),
-        ) { blockOption, timeLimit, intervalLength, intervalWindowStart, intervalUsage ->
-            val intervalState = IntervalTimerState(
-                windowStartMillis = intervalWindowStart,
-                usageMillis = intervalUsage,
-            )
-            Timber.i(
-                "Initializing blocking manager with: option=%s, timeLimit=%d, intervalLength=%d, intervalState=%s",
-                blockOption,
-                timeLimit,
-                intervalLength,
-                intervalState,
-            )
-            createHandlerForConfig(
-                blockOption,
-                timeLimit,
-                intervalLength,
-                intervalState,
-            )
-        }
-            .collect { newHandler ->
-                handler = newHandler
+    override fun init() {
+        serviceScope.launch {
+            combine(
+                userSettingsStore.getActiveBlockOption().distinctUntilChanged(),
+                userSettingsStore.getTimeLimit().distinctUntilChanged(),
+                userSettingsStore.getIntervalLength().distinctUntilChanged(),
+                userSettingsStore.getIntervalWindowStart().distinctUntilChanged(),
+                userSettingsStore.getIntervalUsage().distinctUntilChanged(),
+            ) { blockOption, timeLimit, intervalLength, intervalWindowStart, intervalUsage ->
+                val intervalState = IntervalTimerState(
+                    windowStartMillis = intervalWindowStart,
+                    usageMillis = intervalUsage,
+                )
+                Timber.i(
+                    "Initializing blocking manager with: option=%s, timeLimit=%d, intervalLength=%d, intervalState=%s",
+                    blockOption,
+                    timeLimit,
+                    intervalLength,
+                    intervalState,
+                )
+                createHandlerForConfig(
+                    blockOption,
+                    timeLimit,
+                    intervalLength,
+                    intervalState,
+                )
             }
+                .collect { newHandler ->
+                    handler = newHandler
+                }
+        }
     }
 
     /**
@@ -113,7 +115,7 @@ class BlockingManagerImpl @Inject constructor(
                 intervalLengthMillis = intervalLength,
                 initialState = intervalState,
                 onStateChanged = { state ->
-                    persistenceScope.launch {
+                    serviceScope.launch {
                         userSettingsStore.updateIntervalState(state.windowStartMillis, state.usageMillis)
                     }
                 },

--- a/mobile/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
+++ b/mobile/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
@@ -230,9 +230,8 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
             }
         }
 
-        serviceScope.launch {
-            blockingManager.init()
-        }
+        // Initialize blocking manager
+        blockingManager.init()
 
         // Observe timer overlay enabled changes
         serviceScope.launch {

--- a/mobile/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
+++ b/mobile/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
@@ -40,7 +40,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -144,11 +143,6 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
     private var currentTimerOverlayEnabled: Boolean = false
 
     /**
-     * Current active block option, updated reactively.
-     */
-    private var currentBlockOption: BlockOption = BlockOption.NothingSelected
-
-    /**
      * Epoch millis until which blocking logic should remain paused.
      */
     @Volatile
@@ -219,6 +213,9 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
         Timber.i("Accessibility service connected")
 
         // Check if we need to bring the app to foreground
+        // When a user first opens the app, we show the accessibility permission dialog,
+        //  we set a flag to bring the app to foreground once the permission is granted and the service is connected.
+        // (Just to improve user UX)
         serviceScope.launch {
             val waitingForAccessibility = userSettingsStore.getWaitingForAccessibility().distinctUntilChanged()
             waitingForAccessibility.collect { waiting ->
@@ -233,25 +230,13 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
             }
         }
 
-        // Observe changes to the block config
         serviceScope.launch {
-            val timeLimitFlow = userSettingsStore.getTimeLimit().distinctUntilChanged()
-            val intervalLengthFlow = userSettingsStore.getIntervalLength().distinctUntilChanged()
-            val blockOptionFlow = userSettingsStore.getActiveBlockOption().distinctUntilChanged()
-            combine(timeLimitFlow, intervalLengthFlow, blockOptionFlow) { _, _, blockOption -> blockOption }.collect { blockOption ->
-                Timber.d("Settings changed, re-initializing blocking manager with %s", blockOption)
-                blockingManager.init(blockOption)
-            }
+            blockingManager.init()
         }
 
         // Observe timer overlay enabled changes
         serviceScope.launch {
             userSettingsStore.getTimerOverlayEnabled().collect { currentTimerOverlayEnabled = it }
-        }
-
-        // Observe active block option changes
-        serviceScope.launch {
-            userSettingsStore.getActiveBlockOption().collect { currentBlockOption = it }
         }
 
         // Observe pause toggle


### PR DESCRIPTION
Accessibility service currently has too many responsibilities and it has to know a lot of the project knowledge, this aims to simplify it by moving initialization of blocking manager into its own class

-- Ai generated summary:

This pull request refactors the blocking configuration initialization and observation logic to make it more reactive and robust. The main change is that the `BlockingManager` now observes all relevant user settings and updates its handler automatically whenever any configuration changes, rather than requiring explicit re-initialization with parameters. This simplifies the integration with the accessibility service and reduces duplicated logic.

**Blocking Manager Refactor:**
* The `BlockingManager` interface's `init` method no longer takes a `BlockOption` parameter and instead starts observing all relevant blocking configuration changes internally.
* `BlockingManagerImpl` now uses Kotlin's `combine` and `distinctUntilChanged` operators to reactively observe changes to all blocking-related settings (`BlockOption`, time limit, interval length, etc.), and updates its handler automatically when any change occurs.
* The handler is now initialized with a default value (`NoBlockHandler`) and updated in a thread-safe manner.

**Accessibility Service Simplification:**
* The accessibility service (`ScrollessBlockAccessibilityService`) no longer manually observes and passes individual settings to the blocking manager; it simply calls `blockingManager.init()` once, relying on the manager to handle all updates.
* Removed redundant observation and storage of the current block option in the accessibility service, further simplifying state management.

**Minor Improvements and Cleanup:**
* Added clarifying comments to explain the UX flow around accessibility permission and foregrounding the app.
* Removed unnecessary imports and cleaned up related code. [[1]](diffhunk://#diff-99e5f717ef8282c76f95bccbebacac7614395a49e6f7039f01033d5774e5b0c0L35-R36) [[2]](diffhunk://#diff-dcbfb05b483668b7b69ed4d3d45c04d9fa06053bd6ea4022272774ff4ec78ee1L43)
* Removed the "Star History" section from the `README.md` for documentation clarity.