### PR TITLE
Move screens into feature packages

### DIFF
--- a/mobile/src/main/java/com/scrolless/app/feature/home/HomeScreen.kt
+++ b/mobile/src/main/java/com/scrolless/app/feature/home/HomeScreen.kt
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-package com.scrolless.app.ui.home
+package com.scrolless.app.feature.home
 
 import android.app.Activity
 import androidx.compose.animation.AnimatedContent
@@ -124,13 +124,13 @@ import com.scrolless.app.designsystem.theme.progressbar_red_use
 import com.scrolless.app.designsystem.theme.snapchatColor
 import com.scrolless.app.designsystem.theme.tiktokColor
 import com.scrolless.app.designsystem.theme.youtubeShortsColor
-import com.scrolless.app.ui.home.components.AccessibilityExplainerBottomSheet
-import com.scrolless.app.ui.home.components.AccessibilitySuccessBottomSheet
-import com.scrolless.app.ui.home.components.AccessibilitySuccessBottomSheetPreview
-import com.scrolless.app.ui.home.components.FloatingDebugUsagePanel
-import com.scrolless.app.ui.home.components.HelpDialog
-import com.scrolless.app.ui.home.components.IntervalTimerDialog
-import com.scrolless.app.ui.home.components.TimeLimitDialog
+import com.scrolless.app.feature.home.components.AccessibilityExplainerBottomSheet
+import com.scrolless.app.feature.home.components.AccessibilitySuccessBottomSheet
+import com.scrolless.app.feature.home.components.AccessibilitySuccessBottomSheetPreview
+import com.scrolless.app.feature.home.components.FloatingDebugUsagePanel
+import com.scrolless.app.feature.home.components.HelpDialog
+import com.scrolless.app.feature.home.components.IntervalTimerDialog
+import com.scrolless.app.feature.home.components.TimeLimitDialog
 import com.scrolless.app.ui.theme.ScrollessTheme
 import com.scrolless.app.ui.tooling.DevicePreviews
 import com.scrolless.app.util.formatTime

--- a/mobile/src/main/java/com/scrolless/app/feature/home/HomeViewModel.kt
+++ b/mobile/src/main/java/com/scrolless/app/feature/home/HomeViewModel.kt
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-package com.scrolless.app.ui.home
+package com.scrolless.app.feature.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope

--- a/mobile/src/main/java/com/scrolless/app/feature/home/components/AccessibilityExplainerDialog.kt
+++ b/mobile/src/main/java/com/scrolless/app/feature/home/components/AccessibilityExplainerDialog.kt
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-package com.scrolless.app.ui.home.components
+package com.scrolless.app.feature.home.components
 
 import android.content.Intent
 import androidx.compose.animation.AnimatedVisibility

--- a/mobile/src/main/java/com/scrolless/app/feature/home/components/AccessibilitySuccessBottomSheet.kt
+++ b/mobile/src/main/java/com/scrolless/app/feature/home/components/AccessibilitySuccessBottomSheet.kt
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-package com.scrolless.app.ui.home.components
+package com.scrolless.app.feature.home.components
 
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.EaseInOut

--- a/mobile/src/main/java/com/scrolless/app/feature/home/components/DebugSessionPanel.kt
+++ b/mobile/src/main/java/com/scrolless/app/feature/home/components/DebugSessionPanel.kt
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-package com.scrolless.app.ui.home.components
+package com.scrolless.app.feature.home.components
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween

--- a/mobile/src/main/java/com/scrolless/app/feature/home/components/HelpDialog.kt
+++ b/mobile/src/main/java/com/scrolless/app/feature/home/components/HelpDialog.kt
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-package com.scrolless.app.ui.home.components
+package com.scrolless.app.feature.home.components
 
 import android.content.Intent
 import androidx.compose.foundation.background

--- a/mobile/src/main/java/com/scrolless/app/feature/home/components/IntervalTimerDialog.kt
+++ b/mobile/src/main/java/com/scrolless/app/feature/home/components/IntervalTimerDialog.kt
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-package com.scrolless.app.ui.home.components
+package com.scrolless.app.feature.home.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/mobile/src/main/java/com/scrolless/app/feature/home/components/TimeLimitDialog.kt
+++ b/mobile/src/main/java/com/scrolless/app/feature/home/components/TimeLimitDialog.kt
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-package com.scrolless.app.ui.home.components
+package com.scrolless.app.feature.home.components
 
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable

--- a/mobile/src/main/java/com/scrolless/app/feature/settings/SettingsScreen.kt
+++ b/mobile/src/main/java/com/scrolless/app/feature/settings/SettingsScreen.kt
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-package com.scrolless.app.ui.settings
+package com.scrolless.app.feature.settings
 
 import android.content.res.Configuration
 import androidx.compose.foundation.background

--- a/mobile/src/main/java/com/scrolless/app/feature/settings/SettingsViewModel.kt
+++ b/mobile/src/main/java/com/scrolless/app/feature/settings/SettingsViewModel.kt
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-package com.scrolless.app.ui.settings
+package com.scrolless.app.feature.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope

--- a/mobile/src/main/java/com/scrolless/app/ui/ScrollessApplication.kt
+++ b/mobile/src/main/java/com/scrolless/app/ui/ScrollessApplication.kt
@@ -27,8 +27,8 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.compositionLocalOf
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import com.scrolless.app.ui.home.HomeScreen
-import com.scrolless.app.ui.settings.SettingsScreen
+import com.scrolless.app.feature.home.HomeScreen
+import com.scrolless.app.feature.settings.SettingsScreen
 
 @Composable
 @OptIn(ExperimentalSharedTransitionApi::class)


### PR DESCRIPTION
- Moves the Home and Settings screens from com.scrolless.app.ui.* into com.scrolless.app.feature.* packages.
- Updates app-level imports to point at the new feature package locations.
- Keeps behavior unchanged so this PR is a focused architecture/package move.