### PR TITLE
fix: Repair first_launch_at via Room migration

### DIFF
--- a/core/data/src/main/java/com/scrolless/app/core/data/database/ScrollessDatabase.kt
+++ b/core/data/src/main/java/com/scrolless/app/core/data/database/ScrollessDatabase.kt
@@ -224,20 +224,22 @@ abstract class ScrollessDatabase : RoomDatabase() {
         // exists, the earliest local session is our best persisted lower bound for the install/start date.
         // Room stores session start times as LocalDateTime text, so the SQLite 'utc' modifier converts the
         // local wall-clock value to epoch millis without shifting early-morning sessions to the wrong date.
+        // The timestamp is truncated to seconds before strftime to avoid Android SQLite compatibility issues
+        // with nanosecond fractions emitted by DateTimeFormatter.ISO_LOCAL_DATE_TIME.
         val MIGRATION_8_9 = object : Migration(8, 9) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL(
                     """
                     UPDATE user_settings
                     SET first_launch_at = (
-                        SELECT CAST(strftime('%s', MIN(startDateTime), 'utc') AS INTEGER) * 1000
+                        SELECT CAST(strftime('%s', replace(substr(MIN(startDateTime), 1, 19), 'T', ' '), 'utc') AS INTEGER) * 1000
                         FROM session_segments
                     )
                     WHERE EXISTS (SELECT 1 FROM session_segments)
                         AND (
                             first_launch_at = 0
                             OR first_launch_at > (
-                                SELECT CAST(strftime('%s', MIN(startDateTime), 'utc') AS INTEGER) * 1000
+                                SELECT CAST(strftime('%s', replace(substr(MIN(startDateTime), 1, 19), 'T', ' '), 'utc') AS INTEGER) * 1000
                                 FROM session_segments
                             )
                         )

--- a/core/data/src/main/java/com/scrolless/app/core/data/database/ScrollessDatabase.kt
+++ b/core/data/src/main/java/com/scrolless/app/core/data/database/ScrollessDatabase.kt
@@ -34,7 +34,7 @@ import com.scrolless.app.core.data.database.model.UserSettingsEntity
         UserSettingsEntity::class,
         SessionSegmentEntity::class,
     ],
-    version = 8,
+    version = 9,
     exportSchema = false,
 )
 @TypeConverters(LocalDateTypeConverters::class, BlockableAppTypeConverters::class, LocalDateTimeTypeConverters::class)
@@ -218,6 +218,38 @@ abstract class ScrollessDatabase : RoomDatabase() {
         val MIGRATION_7_8 = object : Migration(7, 8) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE user_settings ADD COLUMN except_reels_sent_by_dm INTEGER NOT NULL DEFAULT 0")
+            }
+        }
+        // Repair first_launch_at values overwritten by the cold-start settings race. When session history
+        // exists, the earliest local session is our best persisted lower bound for the install/start date.
+        // Room stores session start times as LocalDateTime text, so the SQLite 'utc' modifier converts the
+        // local wall-clock value to epoch millis without shifting early-morning sessions to the wrong date.
+        val MIGRATION_8_9 = object : Migration(8, 9) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    UPDATE user_settings
+                    SET first_launch_at = (
+                        SELECT CAST(strftime('%s', MIN(startDateTime), 'utc') AS INTEGER) * 1000
+                        FROM session_segments
+                    )
+                    WHERE EXISTS (SELECT 1 FROM session_segments)
+                        AND (
+                            first_launch_at = 0
+                            OR first_launch_at > (
+                                SELECT CAST(strftime('%s', MIN(startDateTime), 'utc') AS INTEGER) * 1000
+                                FROM session_segments
+                            )
+                        )
+                    """.trimIndent(),
+                )
+                db.execSQL(
+                    """
+                    UPDATE user_settings
+                    SET first_launch_at = CAST(strftime('%s','now') AS INTEGER) * 1000
+                    WHERE first_launch_at = 0
+                    """.trimIndent(),
+                )
             }
         }
     }

--- a/core/data/src/main/java/com/scrolless/app/core/data/di/DataDiModule.kt
+++ b/core/data/src/main/java/com/scrolless/app/core/data/di/DataDiModule.kt
@@ -66,6 +66,7 @@ object DataDiModule {
                 ScrollessDatabase.MIGRATION_5_6,
                 ScrollessDatabase.MIGRATION_6_7,
                 ScrollessDatabase.MIGRATION_7_8,
+                ScrollessDatabase.MIGRATION_8_9,
             ).fallbackToDestructiveMigration(true) // Not recommended but for now it shouldn't matter
             .fallbackToDestructiveMigrationOnDowngrade(true).addCallback(
                 object : RoomDatabase.Callback() {

--- a/feature/home/src/main/java/com/scrolless/app/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/scrolless/app/feature/home/HomeViewModel.kt
@@ -50,6 +50,8 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
+private const val FIRST_LAUNCH_LOADING = -1L
+
 /**
  * ViewModel that handles the business logic and screen state of the HomeScreen.
  */
@@ -78,7 +80,7 @@ class HomeViewModel @Inject constructor(
         reviewPromptDismissed,
     ) { firstLaunchAt, hasSeenReviewPrompt, attemptCount, lastAttemptAt, dismissed ->
         if (dismissed) return@combine false
-        if (firstLaunchAt == -1L) return@combine false
+        if (firstLaunchAt == FIRST_LAUNCH_LOADING) return@combine false
         val now = System.currentTimeMillis()
 
         // Avoid spamming
@@ -95,9 +97,9 @@ class HomeViewModel @Inject constructor(
 
     companion object {
         private const val PROGRESS_MAX = 100
-        private val REVIEW_PROMPT_DELAY_MILLIS = TimeUnit.DAYS.toMillis(1) // Show review popup after 1 day
+        private val REVIEW_PROMPT_DELAY_MILLIS = TimeUnit.MINUTES.toMillis(5) // Show review popup after 5 minutes
         private const val REVIEW_PROMPT_MAX_ATTEMPTS = 3
-        private val REVIEW_PROMPT_RETRY_DELAY_MILLIS = TimeUnit.DAYS.toMillis(2)
+        private val REVIEW_PROMPT_RETRY_DELAY_MILLIS = TimeUnit.DAYS.toMillis(1)
     }
 
     init {
@@ -106,13 +108,6 @@ class HomeViewModel @Inject constructor(
                 if (selectedAnalyticsDate.value.isAfter(today)) {
                     selectedAnalyticsDate.value = today
                 }
-            }
-        }
-
-        viewModelScope.launch {
-            val firstLaunch = userSettingsStore.getFirstLaunchAt().first()
-            if (firstLaunch == 0L) {
-                userSettingsStore.setFirstLaunchAt(System.currentTimeMillis())
             }
         }
     }


### PR DESCRIPTION
There was a bug where first launch at was always being updated to the current day, this was fixed on #142, however users before the fix version would still have the firstLaunch wrong, and this would make the stats not show all data, now with this migration it will put the first launch on the day of the first captured session (the first video that the user saw)

Also reduced the review timing to show after 5 minutes of the user having the app open 

- Incremented database version to 9 and added `MIGRATION_8_9` to repair `first_launch_at` values using session history.
- Removed manual initialization of `first_launch_at` from `HomeViewModel`'s `init` block.
- Updated review prompt timing constants to reduce initial delay to 5 minutes and retry interval to 1 day.
- Introduced `FIRST_LAUNCH_LOADING` constant in `HomeViewModel` for better clarity.