### PR TITLE
ui: smoother background color animation

### DIFF
--- a/core/designsystem/src/main/java/com/scrolless/app/designsystem/theme/Color.kt
+++ b/core/designsystem/src/main/java/com/scrolless/app/designsystem/theme/Color.kt
@@ -247,3 +247,8 @@ val tiktokColor = Color(0xFF00F2EA) // Cyan/aqua
 val youtubeShortsColor = Color(0xFFFFB300) // Amber
 
 val timerOverlayBackgroundColor = Color(0xB3000000) // ~70% alpha black
+
+// Holographic ambient background gradient colors
+val holographicElectricSky = Color(0xFF58C7FF)
+val holographicVioletGlow = Color(0xFF9C7BFF)
+val holographicNeonMint = Color(0xFF5DFFB3)

--- a/core/designsystem/src/main/java/com/scrolless/app/designsystem/util/GradientScrim.kt
+++ b/core/designsystem/src/main/java/com/scrolless/app/designsystem/util/GradientScrim.kt
@@ -87,22 +87,36 @@ fun Modifier.radialGradientScrim(
     } else {
         baseColor
     }
-    val baseAlpha = max(blendedBase.alpha, 0.32f)
-    val highlightMix = (0.48f - (clampedAccentStrength * 0.12f)).coerceIn(0.28f, 0.55f)
-    val palette = listOf(
-        blendedBase.copy(alpha = baseAlpha),
+    val baseAlpha = max(blendedBase.alpha, 0.38f)
+    val highlightMix = (0.85f - (clampedAccentStrength * 0.15f)).coerceIn(0.65f, 0.9f)
+    
+    val holoPalette = listOf(
         lerp(blendedBase, Color(0xFF58C7FF), highlightMix).copy(alpha = baseAlpha), // electric sky
         lerp(blendedBase, Color(0xFF9C7BFF), highlightMix).copy(alpha = baseAlpha), // violet glow
         lerp(blendedBase, Color(0xFF5DFFB3), highlightMix).copy(alpha = baseAlpha), // neon mint
-        blendedBase.copy(alpha = baseAlpha * 0.9f),
+        lerp(blendedBase, Color(0xFF58C7FF), highlightMix).copy(alpha = baseAlpha), // electric sky (loop)
     )
+
+    val palette = if (accentColor != null) {
+        val statusPalette = listOf(
+            accentColor.copy(alpha = baseAlpha),
+            lerp(accentColor, Color.White, 0.25f).copy(alpha = baseAlpha),
+            lerp(accentColor, Color.Black, 0.15f).copy(alpha = baseAlpha),
+            accentColor.copy(alpha = baseAlpha)
+        )
+        holoPalette.zip(statusPalette) { holoColor, statusColor ->
+            lerp(holoColor, statusColor, clampedAccentStrength)
+        }
+    } else {
+        holoPalette
+    }
     val animatedColor = lerpPalette(
         palette = palette,
         fraction = 0.2f + (tintShift * 0.8f),
     )
     val innerAlpha = (baseAlpha * (0.82f + pulse * 0.6f) * (0.85f + (clampedAccentStrength * 0.35f)))
-        .coerceAtMost(0.4f)
-    val midAlpha = (innerAlpha * 0.45f).coerceAtMost(0.22f)
+        .coerceAtMost(0.48f)
+    val midAlpha = (innerAlpha * 0.5f).coerceAtMost(0.28f)
 
     val radialGradient = object : ShaderBrush() {
         override fun createShader(size: Size): Shader {

--- a/core/designsystem/src/main/java/com/scrolless/app/designsystem/util/GradientScrim.kt
+++ b/core/designsystem/src/main/java/com/scrolless/app/designsystem/util/GradientScrim.kt
@@ -31,6 +31,9 @@
  */
 package com.scrolless.app.designsystem.util
 
+import com.scrolless.app.designsystem.theme.holographicElectricSky
+import com.scrolless.app.designsystem.theme.holographicNeonMint
+import com.scrolless.app.designsystem.theme.holographicVioletGlow
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
@@ -91,10 +94,10 @@ fun Modifier.radialGradientScrim(
     val highlightMix = (0.85f - (clampedAccentStrength * 0.15f)).coerceIn(0.65f, 0.9f)
     
     val holoPalette = listOf(
-        lerp(blendedBase, Color(0xFF58C7FF), highlightMix).copy(alpha = baseAlpha), // electric sky
-        lerp(blendedBase, Color(0xFF9C7BFF), highlightMix).copy(alpha = baseAlpha), // violet glow
-        lerp(blendedBase, Color(0xFF5DFFB3), highlightMix).copy(alpha = baseAlpha), // neon mint
-        lerp(blendedBase, Color(0xFF58C7FF), highlightMix).copy(alpha = baseAlpha), // electric sky (loop)
+        lerp(blendedBase, holographicElectricSky, highlightMix).copy(alpha = baseAlpha), // electric sky
+        lerp(blendedBase, holographicVioletGlow, highlightMix).copy(alpha = baseAlpha), // violet glow
+        lerp(blendedBase, holographicNeonMint, highlightMix).copy(alpha = baseAlpha), // neon mint
+        lerp(blendedBase, holographicElectricSky, highlightMix).copy(alpha = baseAlpha), // electric sky (loop)
     )
 
     val palette = if (accentColor != null) {


### PR DESCRIPTION
Currently the animation uses a lot of muted colors that when its rotating between colors (in my opinion) looks ugly. This makes it more vibrant

Refine GradientScrim visual parameters and palette blending logic
- Increased `baseAlpha`, `innerAlpha`, and `midAlpha` thresholds for better visibility.
- Adjusted `highlightMix` calculation to increase visual intensity.
- Implemented a dual-palette blending system that interpolates between holographic colors and status-based colors when an `accentColor` is provided.