### PR TITLE
Fix: Usage not rolling over next day

### DIFF
--- a/app/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
+++ b/app/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
@@ -43,6 +43,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -658,12 +659,6 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
         val sessionTime = System.currentTimeMillis() - session.startedAtMillis
         Timber.d("Exited blocked content. Session=%d ms (app=%s)", sessionTime, session.app)
 
-        // Hide timer overlay if enabled
-        if (currentTimerOverlayEnabled) {
-            Timber.v("Hiding timer overlay")
-            timerOverlayManager.hide()
-        }
-
         stopPeriodicCheck()
         blockedContentSession = null
 
@@ -673,6 +668,24 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
         val exitedApp = session.app
 
         serviceScope.launch(Dispatchers.IO) {
+
+            // Get total time spent on brainrot to show on the overlay timer before hiding
+            val overlaySummaryTotal = if (currentTimerOverlayEnabled) {
+                when (userSettingsStore.getActiveBlockOption().first()) {
+                    BlockOption.IntervalTimer -> userSettingsStore.getIntervalUsage().first() + sessionTime
+                    else -> sessionTracker.getDailyUsage() + sessionTime
+                }
+            } else {
+                null
+            }
+
+            overlaySummaryTotal?.let { total ->
+                mainHandler.post {
+                    Timber.v("Hiding timer overlay")
+                    timerOverlayManager.hide(total, session.startedAtMillis)
+                }
+            }
+
             // Add to usage in memory with per-app tracking
             Timber.d("Recording session usage: %d ms for app: %s (%s)", sessionTime, exitedApp.app.name, exitedApp.packageId)
             sessionTracker.addToDailyUsage(sessionTime, exitedApp.app)

--- a/app/src/main/java/com/scrolless/app/ui/overlay/TimerOverlayManager.kt
+++ b/app/src/main/java/com/scrolless/app/ui/overlay/TimerOverlayManager.kt
@@ -39,8 +39,6 @@ import android.widget.TextView
 import androidx.compose.ui.graphics.toArgb
 import androidx.core.view.WindowInsetsCompat
 import com.scrolless.app.R
-import com.scrolless.app.core.model.BlockOption
-import com.scrolless.app.core.repository.SessionTracker
 import com.scrolless.app.core.repository.UserSettingsStore
 import com.scrolless.app.core.repository.setTimerOverlayPosition
 import com.scrolless.app.designsystem.theme.timerOverlayBackgroundColor
@@ -63,7 +61,6 @@ import timber.log.Timber
  */
 class TimerOverlayManager @Inject constructor(
     private val userSettingsStore: UserSettingsStore,
-    private val sessionTracker: SessionTracker,
 ) {
 
     private var rootView: DragInterceptFrameLayout? = null
@@ -81,8 +78,6 @@ class TimerOverlayManager @Inject constructor(
     private var timerJob: Job? = null
     private var exitAnimationJob: Job? = null
     private var screenBounds: ScreenBounds? = null
-    private var activeBlockOption: BlockOption = BlockOption.NothingSelected
-    private var intervalUsageMillis: Long = 0L
 
     // Drag state
     private var initialX = 0
@@ -90,19 +85,6 @@ class TimerOverlayManager @Inject constructor(
     private var initialTouchX = 0f
     private var initialTouchY = 0f
     private var isDragging = false
-
-    init {
-        coroutineScope.launch {
-            userSettingsStore.getActiveBlockOption().collect { option ->
-                activeBlockOption = option
-            }
-        }
-        coroutineScope.launch {
-            userSettingsStore.getIntervalUsage().collect { usage ->
-                intervalUsageMillis = usage
-            }
-        }
-    }
 
     fun attachServiceContext(context: Context) {
         serviceContext = context
@@ -188,19 +170,18 @@ class TimerOverlayManager @Inject constructor(
         }
     }
 
-    fun hide() {
+    fun hide(summaryTotalMillis: Long, sessionStartAt: Long) {
 
         Timber.d("Hiding overlay view")
-        timerJob?.cancel()
-
-        val sessionMillis = (System.currentTimeMillis() - sessionStartTime).coerceAtLeast(0L)
-        val totalMillis = if (activeBlockOption == BlockOption.IntervalTimer) {
-            intervalUsageMillis + sessionMillis
-        } else {
-            sessionTracker.getDailyUsage() + sessionMillis
+        if (sessionStartTime != sessionStartAt) {
+            Timber.v("Ignoring stale overlay hide for session=%d, current=%d", sessionStartAt, sessionStartTime)
+            return
         }
 
-        timerTextView?.text = totalMillis.formatAsTime()
+        timerJob?.cancel()
+
+        timerTextView?.text = summaryTotalMillis.formatAsTime()
+
         startWiggleAnimation()
 
         exitAnimationJob?.cancel()

--- a/app/src/main/java/com/scrolless/app/ui/overlay/TimerOverlayManager.kt
+++ b/app/src/main/java/com/scrolless/app/ui/overlay/TimerOverlayManager.kt
@@ -59,9 +59,7 @@ import timber.log.Timber
  * A View-based implementation of TimerOverlayManager.
  * Replaces the Compose-based version to resolve drag lag issues.
  */
-class TimerOverlayManager @Inject constructor(
-    private val userSettingsStore: UserSettingsStore,
-) {
+class TimerOverlayManager @Inject constructor(private val userSettingsStore: UserSettingsStore) {
 
     private var rootView: DragInterceptFrameLayout? = null
     private var timerTextView: TextView? = null

--- a/core/data/src/main/java/com/scrolless/app/core/data/database/dao/SessionSegmentDao.kt
+++ b/core/data/src/main/java/com/scrolless/app/core/data/database/dao/SessionSegmentDao.kt
@@ -41,6 +41,9 @@ abstract class SessionSegmentDao : BaseDao<SessionSegmentEntity> {
     @Query("SELECT COALESCE(SUM(durationMillis), 0) FROM session_segments WHERE startDateTime >= :date AND startDateTime < :datePlusOneDay")
     abstract fun getTotalDuration(date: LocalDate, datePlusOneDay: LocalDate): Flow<Long>
 
+    @Query("SELECT COALESCE(SUM(durationMillis), 0) FROM session_segments WHERE startDateTime >= :date AND startDateTime < :datePlusOneDay")
+    abstract suspend fun getTotalDurationSnapshot(date: LocalDate, datePlusOneDay: LocalDate): Long
+
     @Query("DELETE FROM session_segments WHERE startDateTime >= :date AND startDateTime < :datePlusOneDay")
     abstract suspend fun deleteSessionSegment(date: LocalDate, datePlusOneDay: LocalDate): Int
 

--- a/core/data/src/main/java/com/scrolless/app/core/data/repository/SessionSegmentStoreImpl.kt
+++ b/core/data/src/main/java/com/scrolless/app/core/data/repository/SessionSegmentStoreImpl.kt
@@ -36,8 +36,7 @@ class SessionSegmentStoreImpl @Inject constructor(
     private val sessionSegmentDao: SessionSegmentDao,
 ) : SessionSegmentStore {
 
-    override fun observeTotalDuration(date: LocalDate): Flow<Long> =
-        sessionSegmentDao.getTotalDuration(date, date.plusDays(1))
+    override fun observeTotalDuration(date: LocalDate): Flow<Long> = sessionSegmentDao.getTotalDuration(date, date.plusDays(1))
 
     override suspend fun getTodayTotalDurationSnapshot(): Long {
         val today = timeProvider.localDateNow()

--- a/core/data/src/main/java/com/scrolless/app/core/data/repository/SessionSegmentStoreImpl.kt
+++ b/core/data/src/main/java/com/scrolless/app/core/data/repository/SessionSegmentStoreImpl.kt
@@ -25,19 +25,10 @@ import com.scrolless.app.core.model.usage.DailyUsageTotal
 import com.scrolless.app.core.model.usage.calculateDailyTotals
 import com.scrolless.app.core.repository.SessionSegmentStore
 import java.time.LocalDate
-import java.time.ZoneId
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.launch
 
 @Singleton
 class SessionSegmentStoreImpl @Inject constructor(
@@ -45,38 +36,13 @@ class SessionSegmentStoreImpl @Inject constructor(
     private val sessionSegmentDao: SessionSegmentDao,
 ) : SessionSegmentStore {
 
-    private val coroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-    private val _totalDurationForToday = MutableStateFlow(0L)
-    private val currentDay = MutableStateFlow(timeProvider.localDateNow())
+    override fun observeTotalDuration(date: LocalDate): Flow<Long> =
+        sessionSegmentDao.getTotalDuration(date, date.plusDays(1))
 
-    init {
-        coroutineScope.launch {
-            while (isActive) {
-                val zoneId = ZoneId.systemDefault()
-                val today = timeProvider.localDateNow()
-                if (today != currentDay.value) {
-                    currentDay.value = today
-                }
-                val nextMidnight = today.plusDays(1).atStartOfDay(zoneId).toInstant().toEpochMilli()
-                val delayMillis = (nextMidnight - timeProvider.currentTimeInMillis()).coerceAtLeast(1L)
-                delay(delayMillis)
-            }
-        }
-
-        coroutineScope.launch {
-            currentDay.collectLatest { date ->
-                // Cancel the previous day subscription and switch to the new day window.
-                sessionSegmentDao.getTotalDuration(date, date.plusDays(1)).collect { duration ->
-                    _totalDurationForToday.value = duration
-                }
-            }
-        }
+    override suspend fun getTodayTotalDurationSnapshot(): Long {
+        val today = timeProvider.localDateNow()
+        return sessionSegmentDao.getTotalDurationSnapshot(today, today.plusDays(1))
     }
-    override fun getTotalDurationForToday(): Flow<Long> {
-        return _totalDurationForToday
-    }
-
-    override fun getCurrentTotalDurationForToday(): Long = _totalDurationForToday.value
 
     override fun getListSessionSegments(startDate: LocalDate, endDateInclusive: LocalDate): Flow<List<SessionSegment>> {
         val endDateExclusive = endDateInclusive.plusDays(1)

--- a/core/data/src/main/java/com/scrolless/app/core/data/repository/SessionTrackerImpl.kt
+++ b/core/data/src/main/java/com/scrolless/app/core/data/repository/SessionTrackerImpl.kt
@@ -44,7 +44,7 @@ class SessionTrackerImpl @Inject constructor(
     private val usageMutex = Mutex()
     private val sessionState = AtomicReference(SessionState(sessionStartLocalDate = timeProvider.localDateNow()))
 
-    override fun getDailyUsage(): Long = sessionSegmentStore.getCurrentTotalDurationForToday()
+    override suspend fun getDailyUsage(): Long = sessionSegmentStore.getTodayTotalDurationSnapshot()
 
     override suspend fun addToDailyUsage(sessionTime: Long, app: BlockableApp) {
         usageMutex.withLock {

--- a/core/data/src/test/java/com/scrolless/app/core/data/repository/SessionSegmentStoreImplTest.kt
+++ b/core/data/src/test/java/com/scrolless/app/core/data/repository/SessionSegmentStoreImplTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 Scrolless
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.scrolless.app.core.data.repository
+
+import com.scrolless.app.core.blocking.time.TimeProvider
+import com.scrolless.app.core.data.database.dao.SessionSegmentDao
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class SessionSegmentStoreImplTest : BaseTest() {
+
+    private val timeProvider = MutableTimeProvider(LocalDate.of(2026, 6, 19))
+    private val dao = mockk<SessionSegmentDao>()
+    private val store = SessionSegmentStoreImpl(timeProvider = timeProvider, sessionSegmentDao = dao)
+
+    @Test
+    fun `today snapshot does not reuse date from store construction`() = runTest {
+        val yesterday = LocalDate.of(2026, 6, 19)
+        val today = LocalDate.of(2026, 6, 20)
+        timeProvider.currentDate = today
+
+        coEvery { dao.getTotalDurationSnapshot(yesterday, yesterday.plusDays(1)) } returns 99L
+        coEvery { dao.getTotalDurationSnapshot(today, today.plusDays(1)) } returns 0L
+
+        val total = store.getTodayTotalDurationSnapshot()
+
+        assertEquals(0L, total)
+        coVerify(exactly = 0) {
+            dao.getTotalDurationSnapshot(yesterday, yesterday.plusDays(1))
+        }
+        coVerify(exactly = 1) {
+            dao.getTotalDurationSnapshot(today, today.plusDays(1))
+        }
+    }
+
+    private class MutableTimeProvider(var currentDate: LocalDate) : TimeProvider {
+        override fun currentTimeInMillis(): Long =
+            currentDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+
+        override fun localDateNow(): LocalDate = currentDate
+
+        override fun localDateTimeNow(): LocalDateTime = currentDate.atStartOfDay()
+    }
+}

--- a/core/data/src/test/java/com/scrolless/app/core/data/repository/SessionSegmentStoreImplTest.kt
+++ b/core/data/src/test/java/com/scrolless/app/core/data/repository/SessionSegmentStoreImplTest.kt
@@ -58,8 +58,7 @@ class SessionSegmentStoreImplTest : BaseTest() {
     }
 
     private class MutableTimeProvider(var currentDate: LocalDate) : TimeProvider {
-        override fun currentTimeInMillis(): Long =
-            currentDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        override fun currentTimeInMillis(): Long = currentDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
 
         override fun localDateNow(): LocalDate = currentDate
 

--- a/core/data/src/test/java/com/scrolless/app/core/data/repository/SessionTrackerTest.kt
+++ b/core/data/src/test/java/com/scrolless/app/core/data/repository/SessionTrackerTest.kt
@@ -22,7 +22,6 @@ import com.scrolless.app.core.model.SessionSegment
 import com.scrolless.app.core.repository.SessionSegmentStore
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.every
 import io.mockk.mockk
 import java.time.Duration
 import junit.framework.TestCase.assertEquals
@@ -47,8 +46,7 @@ class SessionTrackerTest : BaseTest() {
     private var sessionTracker = SessionTrackerImpl(timeProvider = timeProvider, store)
 
     init {
-        every { store.getTotalDurationForToday() } returns totalDurationForToday
-        every { store.getCurrentTotalDurationForToday() } answers { totalDurationForToday.value }
+        coEvery { store.getTodayTotalDurationSnapshot() } answers { totalDurationForToday.value }
     }
 
     @Test

--- a/core/domain/src/main/java/com/scrolless/app/core/repository/SessionSegmentStore.kt
+++ b/core/domain/src/main/java/com/scrolless/app/core/repository/SessionSegmentStore.kt
@@ -22,9 +22,9 @@ import java.time.LocalDate
 import kotlinx.coroutines.flow.Flow
 
 interface SessionSegmentStore {
-    fun getTotalDurationForToday(): Flow<Long>
+    fun observeTotalDuration(date: LocalDate): Flow<Long>
 
-    fun getCurrentTotalDurationForToday(): Long
+    suspend fun getTodayTotalDurationSnapshot(): Long
 
     fun getListSessionSegments(startDate: LocalDate, endDateInclusive: LocalDate = startDate): Flow<List<SessionSegment>>
 

--- a/core/domain/src/main/java/com/scrolless/app/core/repository/SessionTracker.kt
+++ b/core/domain/src/main/java/com/scrolless/app/core/repository/SessionTracker.kt
@@ -23,7 +23,7 @@ interface SessionTracker {
     /**
      * Get the current total daily usage in milliseconds.
      */
-    fun getDailyUsage(): Long
+    suspend fun getDailyUsage(): Long
 
     /**
      * Add session time to daily usage and persist immediately.

--- a/feature/home/src/main/java/com/scrolless/app/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/scrolless/app/feature/home/HomeViewModel.kt
@@ -155,7 +155,7 @@ class HomeViewModel @Inject constructor(
         userSettingsStore.getIntervalLength(),
         userSettingsStore.getIntervalUsage(),
         userSettingsStore.getIntervalWindowStart(),
-        sessionSegmentStore.getTotalDurationForToday(),
+        currentDate.flatMapLatest { date -> sessionSegmentStore.observeTotalDuration(date) },
         sessionSegmentsForCurrentDay,
     ) { blockOption, timeLimit, intervalLength, intervalUsage, intervalWindowStart, currentUsage, usageSegment ->
         UsageSnapshot(


### PR DESCRIPTION
Fixed usage not rolling over into the next day

Also did some clean up on TimerOverlay, it had getting too much code responsibility, now it only gets the time start and to show before hiding

--  AI Generated Overview

This pull request refactors how daily usage duration is tracked and displayed, shifting from a flow-based, always-on observation model to a more snapshot-based, suspend function approach. It simplifies state management, improves accuracy when the day changes, and ensures overlays display up-to-date usage information. The changes also remove unnecessary dependencies and update related tests.

**Repository and API Refactoring:**

* Changed `SessionSegmentStore` to provide a suspend function `getTodayTotalDurationSnapshot()` for current day's usage, replacing the previous flow-based and cached value approach. Also added `observeTotalDuration(date)` for observing usage on any day. [[1]](diffhunk://#diff-366d90cd6e8c8eef932202a17eeaa94bb64c89e98adc8d1f68f93747fb207b45L25-R27) [[2]](diffhunk://#diff-e9a149d6037aede6d86306420a3e3c5979e9f786c5eec4e52867c65eb6e0e341L28-L79) [[3]](diffhunk://#diff-ab8552f19496678ae50c8ab87d4835ad14e933f4febb40bb2bb4dc9922705f94R44-R46)
* Updated `SessionTracker` and its implementation: `getDailyUsage()` is now a suspend function that fetches the latest usage snapshot, ensuring accuracy across date changes. [[1]](diffhunk://#diff-3f663cd663d77038a2f7d00a2392d2770a751c7327c2e0ed8e9e0a9169286518L26-R26) [[2]](diffhunk://#diff-943453bac773ae65e174924f400226ec922d10c844fb619de2cd61b50d390984L47-R47)

**Timer Overlay and Accessibility Service:**

* Refactored `TimerOverlayManager` to remove internal state and dependencies on `SessionTracker` and `BlockOption`. Now, the overlay is updated and hidden with the correct usage total passed in explicitly, avoiding stale data and unnecessary complexity. [[1]](diffhunk://#diff-8ae1ed642f72617798131bc6a0324d771b41d4ec40445e70e9933ce2faea0209L42-L43) [[2]](diffhunk://#diff-8ae1ed642f72617798131bc6a0324d771b41d4ec40445e70e9933ce2faea0209L66) [[3]](diffhunk://#diff-8ae1ed642f72617798131bc6a0324d771b41d4ec40445e70e9933ce2faea0209L84-L85) [[4]](diffhunk://#diff-8ae1ed642f72617798131bc6a0324d771b41d4ec40445e70e9933ce2faea0209L94-L106) [[5]](diffhunk://#diff-8ae1ed642f72617798131bc6a0324d771b41d4ec40445e70e9933ce2faea0209L191-L203)
* Updated `ScrollessBlockAccessibilityService` to compute and pass the correct summary total to the overlay before hiding it, ensuring the displayed value is always accurate. [[1]](diffhunk://#diff-1639f3e890c9545cc40044792a0bdc82164ce010334ccf694228fdb1d8f2d832R46) [[2]](diffhunk://#diff-1639f3e890c9545cc40044792a0bdc82164ce010334ccf694228fdb1d8f2d832L661-L666) [[3]](diffhunk://#diff-1639f3e890c9545cc40044792a0bdc82164ce010334ccf694228fdb1d8f2d832R671-R688)

**Testing and Cleanup:**

* Added a new test for `SessionSegmentStoreImpl` to verify that the daily usage snapshot always uses the current date, not the construction date, preventing subtle bugs around date rollovers.
* Updated `SessionTrackerTest` to use the new suspend snapshot API. [[1]](diffhunk://#diff-bb5435c872de5c9d00496ad7011c7d218cf224b7c352ec82c88087d60ff0d290L25) [[2]](diffhunk://#diff-bb5435c872de5c9d00496ad7011c7d218cf224b7c352ec82c88087d60ff0d290L50-R49)
* Updated `HomeViewModel` to use the new `observeTotalDuration(date)` API for current day usage.