### PR TITLE
feat(ui): Removed ready text, changed progress bar background color

### DIFF
--- a/feature/home/src/main/java/com/scrolless/app/feature/home/components/ProgressCard.kt
+++ b/feature/home/src/main/java/com/scrolless/app/feature/home/components/ProgressCard.kt
@@ -127,7 +127,7 @@ fun ProgressCard(
 
             intervalLength <= 0L || intervalWindowStart <= 0L -> null
 
-            intervalRemainingMillis <= 1_000L -> stringResource(R.string.interval_timer_next_reset_ready)
+            intervalRemainingMillis <= 1_000L -> null
 
             else -> stringResource(
                 R.string.interval_timer_next_reset_in,
@@ -235,7 +235,7 @@ fun ProgressCard(
                 .padding(16.dp)
                 .hapticClickable(onClick = onClick),
             shape = RoundedCornerShape(96.dp),
-            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primary),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
             elevation = CardDefaults.cardElevation(defaultElevation = 12.dp),
         ) {
             Box(

--- a/feature/home/src/main/res/values-b+sr+Latn/strings.xml
+++ b/feature/home/src/main/res/values-b+sr+Latn/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">Rezultat: do %1$s svakih %2$s</string>
     <string name="interval_timer_dialog_title">Konfigurišite intervalni tajmer</string>
     <string name="interval_timer_next_reset_in">Resetuje se za %1$s</string>
-    <string name="interval_timer_next_reset_ready">Sledeći period korišćenja je otključan</string>
     <string name="limit_chip">%1$s limit</string>
     <string name="next_step_1">Izaberite režim blokiranja</string>
     <string name="next_step_2">Isprobajte funkciju dnevnog limita i aktivirajte preklapanje tajmera</string>

--- a/feature/home/src/main/res/values-ca/strings.xml
+++ b/feature/home/src/main/res/values-ca/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">Resultat: fins a %1$s cada %2$s</string>
     <string name="interval_timer_dialog_title">Configurar temporitzador d\'intervals</string>
     <string name="interval_timer_next_reset_in">Es reinicia en %1$s</string>
-    <string name="interval_timer_next_reset_ready">Pròxima finestra d\'ús desbloquejada</string>
     <string name="limit_chip">Límit de %1$s</string>
     <string name="next_step_1">Selecciona un mode de bloqueig</string>
     <string name="next_step_2">Prova la funció de límit diari i activa la superposició del temporitzador</string>

--- a/feature/home/src/main/res/values-cs/strings.xml
+++ b/feature/home/src/main/res/values-cs/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">Výsledek: až %1$s každých %2$s</string>
     <string name="interval_timer_dialog_title">Konfigurovat časovač intervalů</string>
     <string name="interval_timer_next_reset_in">Resetuje se za %1$s</string>
-    <string name="interval_timer_next_reset_ready">Další okno používání odemčeno</string>
     <string name="limit_chip">Limit %1$s</string>
     <string name="next_step_1">Vyberte režim blokování</string>
     <string name="next_step_2">Vyzkoušejte funkci denního limitu a aktivujte překrytí časovače</string>

--- a/feature/home/src/main/res/values-de/strings.xml
+++ b/feature/home/src/main/res/values-de/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">Ergebnis: bis zu %1$s alle %2$s</string>
     <string name="interval_timer_dialog_title">Intervall-Timer konfigurieren</string>
     <string name="interval_timer_next_reset_in">Zurücksetzung in %1$s</string>
-    <string name="interval_timer_next_reset_ready">Nächstes Nutzungsfenster freigeschaltet</string>
     <string name="limit_chip">%1$s Limit</string>
     <string name="next_step_1">Wählen Sie einen Blockierungsmodus</string>
     <string name="next_step_2">Probieren Sie die Tageslimit-Funktion aus und aktivieren Sie das Timer-Overlay</string>

--- a/feature/home/src/main/res/values-el/strings.xml
+++ b/feature/home/src/main/res/values-el/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">Αποτέλεσμα: έως %1$s κάθε %2$s</string>
     <string name="interval_timer_dialog_title">Διαμόρφωση χρονοδιακόπτη διαστήματος</string>
     <string name="interval_timer_next_reset_in">Επαναφορά σε %1$s</string>
-    <string name="interval_timer_next_reset_ready">Το επόμενο παράθυρο χρήσης ξεκλειδώθηκε</string>
     <string name="limit_chip">Όριο %1$s</string>
     <string name="next_step_1">Επιλέξτε μια λειτουργία αποκλεισμού</string>
     <string name="next_step_2">Δοκιμάστε τη λειτουργία ημερήσιου ορίου και ενεργοποιήστε την επικάλυψη χρονοδιακόπτη</string>

--- a/feature/home/src/main/res/values-es/strings.xml
+++ b/feature/home/src/main/res/values-es/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">Resultado: hasta %1$s cada %2$s</string>
     <string name="interval_timer_dialog_title">Configurar temporizador por intervalos</string>
     <string name="interval_timer_next_reset_in">Se reinicia en %1$s</string>
-    <string name="interval_timer_next_reset_ready">Siguiente ventana de uso desbloqueada</string>
     <string name="limit_chip">Límite de %1$s</string>
     <string name="next_step_1">Selecciona un modo de bloqueo</string>
     <string name="next_step_2">Prueba la función de límite diario y activa el temporizador superpuesto</string>

--- a/feature/home/src/main/res/values-fi-rFI/strings.xml
+++ b/feature/home/src/main/res/values-fi-rFI/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">Tulos: jopa %1$s joka %2$s</string>
     <string name="interval_timer_dialog_title">Määritä aikavälin ajastin</string>
     <string name="interval_timer_next_reset_in">Nollaantuu %1$s kuluttua</string>
-    <string name="interval_timer_next_reset_ready">Seuraava käyttöikkuna avattu</string>
     <string name="limit_chip">%1$s raja</string>
     <string name="next_step_1">Valitse estotila</string>
     <string name="next_step_2">Kokeile päivittäisen rajan ominaisuutta ja aktivoi ajastimen peittokuva</string>

--- a/feature/home/src/main/res/values-fr/strings.xml
+++ b/feature/home/src/main/res/values-fr/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">Résultat : jusqu\'à %1$s toutes les %2$s</string>
     <string name="interval_timer_dialog_title">Configurer le minuteur d\'intervalle</string>
     <string name="interval_timer_next_reset_in">Réinitialisation dans %1$s</string>
-    <string name="interval_timer_next_reset_ready">Prochaine fenêtre d\'utilisation débloquée</string>
     <string name="limit_chip">Limite de %1$s</string>
     <string name="next_step_1">Sélectionnez un mode de blocage</string>
     <string name="next_step_2">Essayez la fonction de limite quotidienne et activez la superposition du minuteur</string>

--- a/feature/home/src/main/res/values-hi/strings.xml
+++ b/feature/home/src/main/res/values-hi/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">परिणाम: प्रत्येक %2$s में %1$s तक</string>
     <string name="interval_timer_dialog_title">अंतराल टाइमर कॉन्फ़िगर करें</string>
     <string name="interval_timer_next_reset_in">%1$s में रीसेट होता है</string>
-    <string name="interval_timer_next_reset_ready">अगली उपयोग विंडो अनलॉक हो गई</string>
     <string name="limit_chip">%1$s सीमा</string>
     <string name="next_step_1">एक ब्लॉकिंग मोड चुनें</string>
     <string name="next_step_2">दैनिक सीमा सुविधा आज़माएं और टाइमर ओवरले सक्रिय करें</string>

--- a/feature/home/src/main/res/values-hr/strings.xml
+++ b/feature/home/src/main/res/values-hr/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">Rezultat: do %1$s svakih %2$s</string>
     <string name="interval_timer_dialog_title">Konfiguriraj mjerač vremena intervala</string>
     <string name="interval_timer_next_reset_in">Poništava se za %1$s</string>
-    <string name="interval_timer_next_reset_ready">Sljedeće razdoblje korištenja otključano</string>
     <string name="limit_chip">%1$s ograničenje</string>
     <string name="next_step_1">Odaberite način blokiranja</string>
     <string name="next_step_2">Isprobajte značajku dnevnog ograničenja i aktivirajte preklapanje mjerača vremena</string>

--- a/feature/home/src/main/res/values-hu/strings.xml
+++ b/feature/home/src/main/res/values-hu/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">Eredmény: akár %1$s minden %2$s-ben</string>
     <string name="interval_timer_dialog_title">Intervallum időzítő konfigurálása</string>
     <string name="interval_timer_next_reset_in">Visszaállítás %1$s múlva</string>
-    <string name="interval_timer_next_reset_ready">Következő használati ablak feloldva</string>
     <string name="limit_chip">%1$s limit</string>
     <string name="next_step_1">Válasszon blokkolási módot</string>
     <string name="next_step_2">Próbálja ki a napi limit funkciót, és aktiválja az időzítő átfedést</string>

--- a/feature/home/src/main/res/values-it/strings.xml
+++ b/feature/home/src/main/res/values-it/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">Risultato: fino a %1$s ogni %2$s</string>
     <string name="interval_timer_dialog_title">Configura il timer a intervalli</string>
     <string name="interval_timer_next_reset_in">Si resetta tra %1$s</string>
-    <string name="interval_timer_next_reset_ready">Prossima finestra di utilizzo sbloccata</string>
     <string name="limit_chip">Limite di %1$s</string>
     <string name="next_step_1">Seleziona una modalità di blocco</string>
     <string name="next_step_2">Prova la funzione limite giornaliero e attiva l\'overlay del timer</string>

--- a/feature/home/src/main/res/values-ja/strings.xml
+++ b/feature/home/src/main/res/values-ja/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">結果: %2$sごとに最大%1$s</string>
     <string name="interval_timer_dialog_title">インターバルタイマーを設定</string>
     <string name="interval_timer_next_reset_in">リセットまで%1$s</string>
-    <string name="interval_timer_next_reset_ready">次の視聴枠が利用可能です</string>
     <string name="limit_chip">%1$s制限</string>
     <string name="next_step_1">ブロックモードを選択</string>
     <string name="next_step_2">1日の制限機能を試して、タイマーオーバーレイを有効にする</string>

--- a/feature/home/src/main/res/values-ml/strings.xml
+++ b/feature/home/src/main/res/values-ml/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">ഫലം: ഓരോ %2$s-ലും %1$s വരെ</string>
     <string name="interval_timer_dialog_title">ഇന്റർവെൽ ടൈമർ ക്രമീകരിക്കുക</string>
     <string name="interval_timer_next_reset_in">%1$s-ൽ പുനഃസജ്ജമാക്കുന്നു</string>
-    <string name="interval_timer_next_reset_ready">അടുത്ത ഉപയോഗ വിൻഡോ അൺലോക്ക് ചെയ്തു</string>
     <string name="limit_chip">%1$s പരിധി</string>
     <string name="next_step_1">ഒരു ബ്ലോക്കിംഗ് മോഡ് തിരഞ്ഞെടുക്കുക</string>
     <string name="next_step_2">പ്രതിദിന പരിധി ഫീച്ചർ പരീക്ഷിച്ച് ടൈമർ ഓവർലേ സജീവമാക്കുക</string>

--- a/feature/home/src/main/res/values-mr/strings.xml
+++ b/feature/home/src/main/res/values-mr/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">परिणाम: प्रत्येक %2$s मध्ये %1$s पर्यंत</string>
     <string name="interval_timer_dialog_title">इंटरव्हल टाइमर कॉन्फिगर करा</string>
     <string name="interval_timer_next_reset_in">%1$s मध्ये रीसेट होते</string>
-    <string name="interval_timer_next_reset_ready">पुढील वापर विंडो अनलॉक झाली</string>
     <string name="limit_chip">%1$s मर्यादा</string>
     <string name="next_step_1">ब्लॉकिंग मोड निवडा</string>
     <string name="next_step_2">दैनिक मर्यादा वैशिष्ट्य वापरून पहा आणि टाइमर आच्छादन सक्रिय करा</string>

--- a/feature/home/src/main/res/values-nb-rNO/strings.xml
+++ b/feature/home/src/main/res/values-nb-rNO/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">Resultat: opptil %1$s hver %2$s</string>
     <string name="interval_timer_dialog_title">Konfigurer intervalltimer</string>
     <string name="interval_timer_next_reset_in">Tilbakestilles om %1$s</string>
-    <string name="interval_timer_next_reset_ready">Neste bruksvindu låst opp</string>
     <string name="limit_chip">%1$s grense</string>
     <string name="next_step_1">Velg en blokkeringsmodus</string>
     <string name="next_step_2">Prøv daglig grense-funksjonen og aktiver timer-overlegget</string>

--- a/feature/home/src/main/res/values-nl/strings.xml
+++ b/feature/home/src/main/res/values-nl/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">Resultaat: tot %1$s elke %2$s</string>
     <string name="interval_timer_dialog_title">Intervaltimer configureren</string>
     <string name="interval_timer_next_reset_in">Reset over %1$s</string>
-    <string name="interval_timer_next_reset_ready">Volgende gebruiksvenster ontgrendeld</string>
     <string name="limit_chip">%1$s limiet</string>
     <string name="next_step_1">Selecteer een blokkeermodus</string>
     <string name="next_step_2">Probeer de dagelijkse limietfunctie en activeer de timeroverlay</string>

--- a/feature/home/src/main/res/values-nn-rNO/strings.xml
+++ b/feature/home/src/main/res/values-nn-rNO/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">Resultat: opptil %1$s kvar %2$s</string>
     <string name="interval_timer_dialog_title">Konfigurer intervalltidtakar</string>
     <string name="interval_timer_next_reset_in">Tilbakestiller om %1$s</string>
-    <string name="interval_timer_next_reset_ready">Neste bruksvindauge låst opp</string>
     <string name="limit_chip">%1$s grense</string>
     <string name="next_step_1">Vel ein blokkeringsmodus</string>
     <string name="next_step_2">Prøv funksjonen for dagleg grense og aktiver tidtakaroverlegget</string>

--- a/feature/home/src/main/res/values-pl/strings.xml
+++ b/feature/home/src/main/res/values-pl/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">Wynik: do %1$s co %2$s</string>
     <string name="interval_timer_dialog_title">Skonfiguruj licznik interwałów</string>
     <string name="interval_timer_next_reset_in">Resetuje się za %1$s</string>
-    <string name="interval_timer_next_reset_ready">Następne okno korzystania odblokowane</string>
     <string name="limit_chip">Limit %1$s</string>
     <string name="next_step_1">Wybierz tryb blokowania</string>
     <string name="next_step_2">Wypróbuj funkcję dziennego limitu i aktywuj nakładkę timera</string>

--- a/feature/home/src/main/res/values-pt-rBR/strings.xml
+++ b/feature/home/src/main/res/values-pt-rBR/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">Resultado: até %1$s a cada %2$s</string>
     <string name="interval_timer_dialog_title">Configurar temporizador de intervalo</string>
     <string name="interval_timer_next_reset_in">Reinicia em %1$s</string>
-    <string name="interval_timer_next_reset_ready">Próxima janela de uso desbloqueada</string>
     <string name="limit_chip">Limite de %1$s</string>
     <string name="next_step_1">Selecione um modo de bloqueio</string>
     <string name="next_step_2">Experimente o recurso de limite diário e ative o timer sobreposto</string>

--- a/feature/home/src/main/res/values-pt/strings.xml
+++ b/feature/home/src/main/res/values-pt/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">Resultado: até %1$s a cada %2$s</string>
     <string name="interval_timer_dialog_title">Configurar temporizador de intervalo</string>
     <string name="interval_timer_next_reset_in">Reinicia em %1$s</string>
-    <string name="interval_timer_next_reset_ready">Próxima janela de utilização desbloqueada</string>
     <string name="limit_chip">Limite de %1$s</string>
     <string name="next_step_1">Selecione um modo de bloqueio</string>
     <string name="next_step_2">Experimente a funcionalidade de limite diário e ative a sobreposição do temporizador</string>

--- a/feature/home/src/main/res/values-ro/strings.xml
+++ b/feature/home/src/main/res/values-ro/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">Rezultat: până la %1$s la fiecare %2$s</string>
     <string name="interval_timer_dialog_title">Configurează temporizatorul pe intervale</string>
     <string name="interval_timer_next_reset_in">Se resetează în %1$s</string>
-    <string name="interval_timer_next_reset_ready">Următoarea fereastră de utilizare este deblocată</string>
     <string name="limit_chip">Limită de %1$s</string>
     <string name="next_step_1">Selectează un mod de blocare</string>
     <string name="next_step_2">Încearcă funcția de limită zilnică și activează temporizatorul suprapus</string>

--- a/feature/home/src/main/res/values-ru/strings.xml
+++ b/feature/home/src/main/res/values-ru/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">Результат: до %1$s каждые %2$s</string>
     <string name="interval_timer_dialog_title">Настроить интервальный таймер</string>
     <string name="interval_timer_next_reset_in">Сброс через %1$s</string>
-    <string name="interval_timer_next_reset_ready">Следующее окно использования разблокировано</string>
     <string name="limit_chip">Лимит %1$s</string>
     <string name="next_step_1">Выберите режим блокировки</string>
     <string name="next_step_2">Попробуйте функцию дневного лимита и активируйте наложение таймера</string>

--- a/feature/home/src/main/res/values-sk-rSK/strings.xml
+++ b/feature/home/src/main/res/values-sk-rSK/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">Výsledok: až %1$s každých %2$s</string>
     <string name="interval_timer_dialog_title">Konfigurovať časovač intervalov</string>
     <string name="interval_timer_next_reset_in">Resetuje sa za %1$s</string>
-    <string name="interval_timer_next_reset_ready">Ďalšie okno používania odomknuté</string>
     <string name="limit_chip">%1$s limit</string>
     <string name="next_step_1">Vyberte režim blokovania</string>
     <string name="next_step_2">Vyskúšajte funkciu denného limitu a aktivujte prekrytie časovača</string>

--- a/feature/home/src/main/res/values-sr/strings.xml
+++ b/feature/home/src/main/res/values-sr/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">Резултат: до %1$s на сваких %2$s</string>
     <string name="interval_timer_dialog_title">Подесите тајмер интервала</string>
     <string name="interval_timer_next_reset_in">Ресетује се за %1$s</string>
-    <string name="interval_timer_next_reset_ready">Следећи период коришћења је откључан</string>
     <string name="limit_chip">Лимит %1$s</string>
     <string name="next_step_1">Изаберите режим блокирања</string>
     <string name="next_step_2">Испробајте функцију дневног лимита и активирајте преклопни тајмер</string>

--- a/feature/home/src/main/res/values-sv-rSE/strings.xml
+++ b/feature/home/src/main/res/values-sv-rSE/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">Resultat: upp till %1$s var %2$s</string>
     <string name="interval_timer_dialog_title">Konfigurera intervalltimer</string>
     <string name="interval_timer_next_reset_in">Återställs om %1$s</string>
-    <string name="interval_timer_next_reset_ready">Nästa användningsfönster upplåst</string>
     <string name="limit_chip">%1$s gräns</string>
     <string name="next_step_1">Välj ett blockeringsläge</string>
     <string name="next_step_2">Prova funktionen för daglig gräns och aktivera timeröverlägget</string>

--- a/feature/home/src/main/res/values-ta-rIN/strings.xml
+++ b/feature/home/src/main/res/values-ta-rIN/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">முடிவு: ஒவ்வொரு %2$s க்கும் %1$s வரை</string>
     <string name="interval_timer_dialog_title">இடைவெளி டைமரை உள்ளமைக்கவும்</string>
     <string name="interval_timer_next_reset_in">%1$s இல் மீட்டமைக்கிறது</string>
-    <string name="interval_timer_next_reset_ready">அடுத்த பயன்பாட்டு சாளரம் திறக்கப்பட்டது</string>
     <string name="limit_chip">%1$s வரம்பு</string>
     <string name="next_step_1">தடுக்கும் பயன்முறையைத் தேர்ந்தெடுக்கவும்</string>
     <string name="next_step_2">தினசரி வரம்பு அம்சத்தை முயற்சித்து டைமர் ஓவர்லேயரைச் செயல்படுத்தவும்</string>

--- a/feature/home/src/main/res/values-tr-rTR/strings.xml
+++ b/feature/home/src/main/res/values-tr-rTR/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">Sonuç: her %2$s için %1$s\'ye kadar</string>
     <string name="interval_timer_dialog_title">Aralık zamanlayıcısını yapılandır</string>
     <string name="interval_timer_next_reset_in">%1$s içinde sıfırlanır</string>
-    <string name="interval_timer_next_reset_ready">Sonraki kullanım penceresi açıldı</string>
     <string name="limit_chip">%1$s sınırı</string>
     <string name="next_step_1">Bir engelleme modu seçin</string>
     <string name="next_step_2">Günlük sınır özelliğini deneyin ve zamanlayıcı yer paylaşımını etkinleştirin</string>

--- a/feature/home/src/main/res/values-uk-rUA/strings.xml
+++ b/feature/home/src/main/res/values-uk-rUA/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">Результат: до %1$s кожні %2$s</string>
     <string name="interval_timer_dialog_title">Налаштувати таймер інтервалів</string>
     <string name="interval_timer_next_reset_in">Скидання через %1$s</string>
-    <string name="interval_timer_next_reset_ready">Наступне вікно використання розблоковано</string>
     <string name="limit_chip">Ліміт %1$s</string>
     <string name="next_step_1">Виберіть режим блокування</string>
     <string name="next_step_2">Спробуйте функцію щоденного ліміту та активуйте накладання таймера</string>

--- a/feature/home/src/main/res/values-vi/strings.xml
+++ b/feature/home/src/main/res/values-vi/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">Kết quả: tối đa %1$s mỗi %2$s</string>
     <string name="interval_timer_dialog_title">Cấu hình hẹn giờ khoảng thời gian</string>
     <string name="interval_timer_next_reset_in">Đặt lại sau %1$s</string>
-    <string name="interval_timer_next_reset_ready">Khung sử dụng tiếp theo đã mở khóa</string>
     <string name="limit_chip">Giới hạn %1$s</string>
     <string name="next_step_1">Chọn chế độ chặn</string>
     <string name="next_step_2">Thử tính năng giới hạn hàng ngày và kích hoạt lớp phủ hẹn giờ</string>

--- a/feature/home/src/main/res/values-zh-rCN/strings.xml
+++ b/feature/home/src/main/res/values-zh-rCN/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">结果：每 %2$s 最多 %1$s</string>
     <string name="interval_timer_dialog_title">配置间隔计时器</string>
     <string name="interval_timer_next_reset_in">%1$s 后重置</string>
-    <string name="interval_timer_next_reset_ready">下一个使用时段已解锁</string>
     <string name="limit_chip">%1$s 限制</string>
     <string name="next_step_1">选择一个屏蔽模式</string>
     <string name="next_step_2">尝试每日限制功能并激活计时器叠加层</string>

--- a/feature/home/src/main/res/values-zh-rTW/strings.xml
+++ b/feature/home/src/main/res/values-zh-rTW/strings.xml
@@ -60,7 +60,6 @@
     <string name="interval_timer_dialog_summary">結果：每 %2$s 最多 %1$s</string>
     <string name="interval_timer_dialog_title">設定間隔計時器</string>
     <string name="interval_timer_next_reset_in">將在 %1$s 後重設</string>
-    <string name="interval_timer_next_reset_ready">下一個使用時段已解鎖</string>
     <string name="limit_chip">%1$s 限制</string>
     <string name="next_step_1">選擇封鎖模式</string>
     <string name="next_step_2">嘗試每日限制功能並啟用計時器疊加層</string>

--- a/feature/home/src/main/res/values/strings.xml
+++ b/feature/home/src/main/res/values/strings.xml
@@ -123,9 +123,6 @@
 
     <string name="interval_timer_next_reset_in">Resets in %1$s</string>
 
-    <string name="interval_timer_next_reset_ready">Next break unlocked</string>
-
-
 
     <string name="limit_chip">%1$s limit</string>
 


### PR DESCRIPTION
Removed ugly ready text on interval timer and changed progress bar color to a more neutral color (primary container)

---- AI Generated Overview:

This pull request updates the `ProgressCard` UI and cleans up interval timer string resources across multiple languages. The main focus is on removing the "next reset ready" message from the interval timer and improving the card's appearance.

**UI Improvements:**

* Changed the `ProgressCard`'s background color from `primary` to `primaryContainer` for better visual consistency. (`ProgressCard.kt`)

**Interval Timer Logic:**

* Removed the display of the "next reset ready" message when the interval timer is about to reset; now, no message is shown in this state. (`ProgressCard.kt`)

**Localization Cleanup:**

* Removed the `interval_timer_next_reset_ready` string from all language resource files, since it is no longer used in the UI. [[1]](diffhunk://#diff-a2f5201ee8b4363f75e1673bdc66f06babd102bdaffcb386d39e588c30151eb9L63) [[2]](diffhunk://#diff-623564d64573687c453f542647090c3bab39c9d4c7dbcfc1c95dc790b8b58e2aL63) [[3]](diffhunk://#diff-9e28dd16d1034baf4efe76b2138eb351b67c2464826cb64bb54f1fa86f3cc459L63) [[4]](diffhunk://#diff-918f9dc8c9468f9ccb51071cc0bbb3992342d94ca1a9a86bd3fcfa6d3fab340bL63) [[5]](diffhunk://#diff-3046948f8803c201dd797c7b99b88f98f95cfc51ed22cbf184946027104574deL63) [[6]](diffhunk://#diff-22c10deb370d29652a5470197734b6ecfeda92436530437ccc8e6cf2c703e4a2L63) [[7]](diffhunk://#diff-0fccccae7803c7fb0b431456fa5a448fc04c9e8740f4b37a3ced4dba25b3c454L63) [[8]](diffhunk://#diff-83a1e7fa2494621dee2cb81141a37b5a5b28f24e9a4059f3842e356ee60ec010L63) [[9]](diffhunk://#diff-ca88f024134bdd5d925b174cf2a7d7eea55fcb5b9e59efeccb8d4f0058656bb3L63) [[10]](diffhunk://#diff-eb0874beb3cfe524c3d23d7d5a2a71e1d088ee9e56f3c32b245c847af1ec7c0cL63) [[11]](diffhunk://#diff-68e8a84d73a8263d29be20a8e5a9780e5fb7bd3e7e625f6b0bad6e7bb461795aL63) [[12]](diffhunk://#diff-ece41fdc8a4221610ad405426b752359206af6c78e618cd5289185358a8da621L63) [[13]](diffhunk://#diff-3170eb1d8761e9c379771928e5335e221d5e12e5da2e174c008af6b522ea1a83L63) [[14]](diffhunk://#diff-539f863a611965b1ccd5378dfb5f27eaf6ffa367559bbdb4f8a9fb9782b1207bL63) [[15]](diffhunk://#diff-64574761bb4e8b3087d9f443d31549fb7926bdeb71f066d7edfdf9e862af1146L63) [[16]](diffhunk://#diff-e75c9f88d7244a721309fb631b5c5a78d2e2ee1626a97a223e2e1013fe28e535L63) [[17]](diffhunk://#diff-1eafa7dc6c1d9f379361b64a9e75d17d8d6a8cb167024d4ad360c6757dd8d8e0L63) [[18]](diffhunk://#diff-950234d2f7e98d6eed28ccdf5a22e371a735153e24ab04894c24dc0b31da88d6L63) [[19]](diffhunk://#diff-b65f844ab031d2efe16ec4f6bc2d3daab8c67152bb6ef463960d2c054341aa6bL63)