### PR TITLE
fix: Facebook detection

### DIFF
--- a/app/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
+++ b/app/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
@@ -31,6 +31,7 @@ import com.scrolless.app.core.model.BlockOption
 import com.scrolless.app.core.model.BlockableApp
 import com.scrolless.app.core.model.BlockingResult
 import com.scrolless.app.core.model.DetectionMethod
+import com.scrolless.app.core.model.DetectionNode
 import com.scrolless.app.core.model.ResolvedBlockableApp
 import com.scrolless.app.core.repository.SessionTracker
 import com.scrolless.app.core.repository.UserSettingsStore
@@ -792,32 +793,20 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
      * to support both signals here.
      */
     private fun AccessibilityNodeInfo.matchesBlockedContent(blockableApp: ResolvedBlockableApp): Boolean {
-        return matchesDetectionMethod(blockableApp, blockableApp.getDetectionMethod())
+        val detectionMethod = blockableApp.getDetectionMethod()
+
+        // View IDs are indexed by Android, so use the platform lookup instead of walking the tree.
+        if (detectionMethod is DetectionMethod.ViewId) {
+            return findAccessibilityNodeInfosByViewId(blockableApp.getViewId(detectionMethod)).any(::isNodeVisibleToTheUser)
+        }
+
+        return matchesComplexBlockedContent(blockableApp)
     }
 
     private fun AccessibilityNodeInfo.shouldSuppressBlocking(blockableApp: ResolvedBlockableApp): Boolean {
         return blockableApp.app == BlockableApp.REELS &&
             currentExceptReelsSentByDm &&
             isInstagramReelSentInDm(blockableApp)
-    }
-
-    private fun AccessibilityNodeInfo.matchesDetectionMethod(
-        blockableApp: ResolvedBlockableApp,
-        detectionMethod: DetectionMethod,
-    ): Boolean {
-        return when (detectionMethod) {
-            is DetectionMethod.ViewId ->
-                findAccessibilityNodeInfosByViewId(blockableApp.getViewId(detectionMethod)).any(::isNodeVisibleToTheUser)
-
-            is DetectionMethod.ContentDescriptions ->
-                hasVisibleContentDescription(detectionMethod.contentDescriptions)
-
-            is DetectionMethod.ContentDescriptionPrefix ->
-                hasVisibleContentDescriptionPrefix(detectionMethod)
-
-            is DetectionMethod.AnyOf ->
-                detectionMethod.detectionMethods.any { matchesDetectionMethod(blockableApp, it) }
-        }
     }
 
     private fun AccessibilityNodeInfo.isInstagramReelSentInDm(blockableApp: ResolvedBlockableApp): Boolean {
@@ -837,58 +826,64 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
     }
 
     /**
-     * Content descriptions are not indexed like view IDs, so we have to walk the visible accessibility tree
-     * and look for a matching node
+     * Scans the Facebook tree once. Cheap single-node rules return immediately; only node classes used
+     * by structural rules are retained for the hierarchy matcher.
      */
-    private fun AccessibilityNodeInfo.hasVisibleContentDescription(contentDescriptions: Set<String>): Boolean {
-        return hasVisibleNodeMatching { node ->
-            node.contentDescription?.toString() in contentDescriptions
-        }
-    }
-
-    /**
-     * Prefix matching for content descriptions lets us target stable navigation labels such as
-     * "Reels, tab 2 of 6" without treating every visible "Reels" label in the feed as a block trigger.
-     */
-    private fun AccessibilityNodeInfo.hasVisibleContentDescriptionPrefix(
-        detectionMethod: DetectionMethod.ContentDescriptionPrefix,
-    ): Boolean {
+    private fun AccessibilityNodeInfo.matchesComplexBlockedContent(blockableApp: ResolvedBlockableApp): Boolean {
+        val structuralNodes = mutableListOf<DetectionNode>()
+        val structuralClassNames = blockableApp.getStructuralClassNames()
+        val nodesToVisit = ArrayDeque<Pair<AccessibilityNodeInfo, Int?>>()
         val rootBounds = android.graphics.Rect().also(::getBoundsInScreen)
-        val maxTop = detectionMethod.maxTopScreenFraction?.let { fraction ->
-            val clampedFraction = fraction.coerceIn(0f, 1f)
-            rootBounds.top + (rootBounds.height() * clampedFraction).toInt()
-        }
-
-        return hasVisibleNodeMatching { node ->
-            val contentDescription = node.contentDescription?.toString() ?: return@hasVisibleNodeMatching false
-            val matchesPrefix = detectionMethod.prefixes.any(contentDescription::startsWith)
-            if (!matchesPrefix) {
-                return@hasVisibleNodeMatching false
-            }
-
-            val nodeBounds = android.graphics.Rect().also(node::getBoundsInScreen)
-            val matchesSelectedState = !detectionMethod.requireSelected || node.isSelected
-            val matchesTopConstraint = maxTop == null || nodeBounds.bottom <= maxTop
-            matchesSelectedState && matchesTopConstraint
-        }
-    }
-
-    private fun AccessibilityNodeInfo.hasVisibleNodeMatching(matchesNode: (AccessibilityNodeInfo) -> Boolean): Boolean {
-        val nodesToVisit = ArrayDeque<AccessibilityNodeInfo>()
-        nodesToVisit.add(this)
+        var nextStructuralNodeId = 0
+        nodesToVisit.add(this to null)
 
         while (nodesToVisit.isNotEmpty()) {
-            val node = nodesToVisit.removeFirst()
-            if (isNodeVisibleToTheUser(node) && matchesNode(node)) {
-                return true
+            val (node, parentStructuralNodeId) = nodesToVisit.removeFirst()
+            val isVisible = isNodeVisibleToTheUser(node)
+            var structuralNodeId: Int? = null
+
+            // Invisible nodes cannot match any rule. But still visit their children because Android can
+            // expose visible descendants below an invisible accessibility wrapper.
+            if (isVisible) {
+                val fastNode = DetectionNode(
+                    nodeId = -1,
+                    viewId = node.viewIdResourceName,
+                    contentDescription = node.contentDescription?.toString(),
+                    isSelected = node.isSelected,
+                )
+
+                if (blockableApp.matchesFastDetectionNode(fastNode)) {
+                    return true
+                }
+
+                val className = node.className?.toString()
+                if (className in structuralClassNames) {
+                    val nodeBounds = android.graphics.Rect().also(node::getBoundsInScreen)
+                    val nodeId = nextStructuralNodeId++
+                    structuralNodeId = nodeId
+                    structuralNodes += DetectionNode(
+                        nodeId = nodeId,
+                        parentNodeId = parentStructuralNodeId,
+                        className = className,
+                        screenWidthFraction = nodeBounds.width().fractionOf(rootBounds.width()),
+                        screenHeightFraction = nodeBounds.height().fractionOf(rootBounds.height()),
+                        isScrollable = node.isScrollable,
+                        isLongClickable = node.isLongClickable,
+                    )
+                }
             }
 
+            val childStructuralParentId = structuralNodeId ?: parentStructuralNodeId
             for (index in 0 until node.childCount) {
-                node.getChild(index)?.let(nodesToVisit::addLast)
+                node.getChild(index)?.let { child -> nodesToVisit.addLast(child to childStructuralParentId) }
             }
         }
 
-        return false
+        return blockableApp.matchesDetectionNodes(structuralNodes)
+    }
+
+    private fun Int.fractionOf(total: Int): Float {
+        return if (total > 0) (toFloat() / total).coerceIn(0f, 1f) else 0f
     }
 
     /**

--- a/core/domain/src/main/java/com/scrolless/app/core/model/BlockableApp.kt
+++ b/core/domain/src/main/java/com/scrolless/app/core/model/BlockableApp.kt
@@ -41,7 +41,6 @@ sealed class DetectionMethod {
         }
     }
     data class AnyOf(val detectionMethods: List<DetectionMethod>) : DetectionMethod()
-    data class AllOf(val detectionMethods: List<DetectionMethod>) : DetectionMethod()
 }
 
 /**
@@ -204,9 +203,6 @@ data class ResolvedBlockableApp(val app: BlockableApp, val packageId: String) {
             is DetectionMethod.NodeStructure -> false
 
             is DetectionMethod.AnyOf -> detectionMethods.any { method -> method.matchesFastNode(node) }
-
-            is DetectionMethod.AllOf ->
-                detectionMethods.isNotEmpty() && detectionMethods.all { method -> method.matchesFastNode(node) }
         }
     }
 
@@ -218,8 +214,6 @@ data class ResolvedBlockableApp(val app: BlockableApp, val packageId: String) {
             }
 
             is DetectionMethod.AnyOf -> detectionMethods.forEach { method -> method.collectStructuralClassNames(destination) }
-
-            is DetectionMethod.AllOf -> detectionMethods.forEach { method -> method.collectStructuralClassNames(destination) }
 
             is DetectionMethod.ViewId,
             is DetectionMethod.ContentDescriptions,
@@ -241,8 +235,6 @@ data class ResolvedBlockableApp(val app: BlockableApp, val packageId: String) {
             }
 
             is DetectionMethod.AnyOf -> detectionMethods.any { method -> method.matches(nodes, childrenByParentId) }
-
-            is DetectionMethod.AllOf -> detectionMethods.all { method -> method.matches(nodes, childrenByParentId) }
         }
     }
 

--- a/core/domain/src/main/java/com/scrolless/app/core/model/BlockableApp.kt
+++ b/core/domain/src/main/java/com/scrolless/app/core/model/BlockableApp.kt
@@ -26,13 +26,44 @@ import androidx.compose.runtime.Immutable
 sealed class DetectionMethod {
     data class ViewId(val viewId: String) : DetectionMethod()
     data class ContentDescriptions(val contentDescriptions: Set<String>) : DetectionMethod()
-    data class ContentDescriptionPrefix(
-        val prefixes: Set<String>,
-        val requireSelected: Boolean = false,
-        val maxTopScreenFraction: Float? = null,
-    ) : DetectionMethod()
+    data class ContentDescriptionPrefix(val prefixes: Set<String>, val requireSelected: Boolean = false) : DetectionMethod()
+    data class NodeStructure(
+        val classNames: Set<String>,
+        val minScreenWidthFraction: Float = 0f,
+        val minScreenHeightFraction: Float = 0f,
+        val requireScrollable: Boolean = false,
+        val requireLongClickable: Boolean = false,
+        val descendant: NodeStructure? = null,
+    ) : DetectionMethod() {
+        init {
+            require(minScreenWidthFraction in 0f..1f)
+            require(minScreenHeightFraction in 0f..1f)
+        }
+    }
     data class AnyOf(val detectionMethods: List<DetectionMethod>) : DetectionMethod()
+    data class AllOf(val detectionMethods: List<DetectionMethod>) : DetectionMethod()
 }
+
+/**
+ * The small, stable subset of an accessibility node needed by content detection.
+ *
+ * Keeping matching independent from [android.view.accessibility.AccessibilityNodeInfo] makes detection
+ * rules deterministic and testable against captured UI-tree signals from third-party apps.
+ */
+@Immutable
+data class DetectionNode(
+    val nodeId: Int,
+    val parentNodeId: Int? = null,
+    val viewId: String? = null,
+    val contentDescription: String? = null,
+    val className: String? = null,
+    val screenWidthFraction: Float = 0f,
+    val screenHeightFraction: Float = 0f,
+    val isVisible: Boolean = true,
+    val isSelected: Boolean = false,
+    val isScrollable: Boolean = false,
+    val isLongClickable: Boolean = false,
+)
 
 // Declares each supported app together with the package names we match, the detection signal to look for,
 //  and the exit action to use once blocked content is found.
@@ -68,12 +99,13 @@ enum class BlockableApp(
     ),
     FACEBOOK(
         packageIds = listOf("com.facebook.katana"),
-        // Facebook needs several detection methods because there's different ways of watching reels
-        // 1. By pressing on a reel in the main feed
-        //      - Easy detection by the content descriptions Sticker & GIF
-        // 2. By pressing the Reels tab
-        //      - Here we expect the selected top navigation accessibility label to start with "Reels, tab"
-        //      - The reason for not just matching "Reels" is that this text can also appear in the user feed
+        // Facebook exposes different accessibility trees depending on how a Reel is opened and changes
+        // its user-facing labels with the app language.
+        // 1. Legacy Reel viewers expose internal composer attachment labels.
+        // 2. "Reels" text content seems to remain stable in many locales. A selected navigation
+        //    label beginning with "Reels," is a useful fast path, but is not required for other languages.
+        // 3. The fallback requires one real viewer subtree: a large scrolling viewer that
+        //    contains a large, long-clickable item, which itself contains the large video surface.
         detectionMethod = DetectionMethod.AnyOf(
             listOf(
                 DetectionMethod.ContentDescriptions(
@@ -82,12 +114,26 @@ enum class BlockableApp(
                         "FbShortsComposerAttachmentComponentSpec_GIF",
                     ),
                 ),
-                // Facebook also shows feed shelves labeled just "Reels", which should not trigger blocking.
-                // so we search for the accessibility label to start with "Reels, tab" (for example "Reels, tab 2 of 6").
                 DetectionMethod.ContentDescriptionPrefix(
-                    prefixes = setOf("Reels, tab"),
+                    prefixes = setOf("Reels,"),
                     requireSelected = true,
-                    maxTopScreenFraction = 0.2f,
+                ),
+                DetectionMethod.NodeStructure(
+                    classNames = setOf("androidx.recyclerview.widget.RecyclerView"),
+                    minScreenWidthFraction = 0.9f,
+                    minScreenHeightFraction = 0.75f,
+                    requireScrollable = true,
+                    descendant = DetectionMethod.NodeStructure(
+                        classNames = setOf("android.widget.Button"),
+                        minScreenWidthFraction = 0.9f,
+                        minScreenHeightFraction = 0.75f,
+                        requireLongClickable = true,
+                        descendant = DetectionMethod.NodeStructure(
+                            classNames = setOf("android.view.SurfaceView"),
+                            minScreenWidthFraction = 0.9f,
+                            minScreenHeightFraction = 0.75f,
+                        ),
+                    ),
                 ),
             ),
         ),
@@ -124,4 +170,104 @@ data class ResolvedBlockableApp(val app: BlockableApp, val packageId: String) {
     fun getExitStrategy(): Int = app.getExitStrategy()
 
     fun getViewId(detectionMethod: DetectionMethod.ViewId): String = "$packageId:id/${detectionMethod.viewId}"
+
+    fun matchesDetectionNodes(nodes: Collection<DetectionNode>): Boolean {
+        val childrenByParentId = nodes.groupBy(DetectionNode::parentNodeId)
+        return getDetectionMethod().matches(nodes, childrenByParentId)
+    }
+
+    /** Returns true only for cheap, single-node rules. A false result may still match a structural rule. */
+    fun matchesFastDetectionNode(node: DetectionNode): Boolean {
+        return getDetectionMethod().matchesFastNode(node)
+    }
+
+    fun getStructuralClassNames(): Set<String> {
+        return buildSet { getDetectionMethod().collectStructuralClassNames(this) }
+    }
+
+    private fun DetectionMethod.matchesFastNode(node: DetectionNode): Boolean {
+        if (!node.isVisible) return false
+        return when (this) {
+            is DetectionMethod.ViewId -> node.viewId == getViewId(this)
+
+            is DetectionMethod.ContentDescriptions -> {
+                val description = node.contentDescription ?: return false
+                contentDescriptions.any { expected -> description.equals(expected, ignoreCase = true) }
+            }
+
+            is DetectionMethod.ContentDescriptionPrefix -> {
+                val description = node.contentDescription ?: return false
+                val prefixMatches = prefixes.any { prefix -> description.startsWith(prefix, ignoreCase = true) }
+                prefixMatches && (!requireSelected || node.isSelected)
+            }
+
+            is DetectionMethod.NodeStructure -> false
+
+            is DetectionMethod.AnyOf -> detectionMethods.any { method -> method.matchesFastNode(node) }
+
+            is DetectionMethod.AllOf ->
+                detectionMethods.isNotEmpty() && detectionMethods.all { method -> method.matchesFastNode(node) }
+        }
+    }
+
+    private fun DetectionMethod.collectStructuralClassNames(destination: MutableSet<String>) {
+        when (this) {
+            is DetectionMethod.NodeStructure -> {
+                destination += classNames
+                descendant?.collectStructuralClassNames(destination)
+            }
+
+            is DetectionMethod.AnyOf -> detectionMethods.forEach { method -> method.collectStructuralClassNames(destination) }
+
+            is DetectionMethod.AllOf -> detectionMethods.forEach { method -> method.collectStructuralClassNames(destination) }
+
+            is DetectionMethod.ViewId,
+            is DetectionMethod.ContentDescriptions,
+            is DetectionMethod.ContentDescriptionPrefix,
+            -> Unit
+        }
+    }
+
+    private fun DetectionMethod.matches(nodes: Collection<DetectionNode>, childrenByParentId: Map<Int?, List<DetectionNode>>): Boolean {
+        return when (this) {
+            is DetectionMethod.ViewId -> nodes.any { node -> matchesFastNode(node) }
+
+            is DetectionMethod.ContentDescriptions -> nodes.any { node -> matchesFastNode(node) }
+
+            is DetectionMethod.ContentDescriptionPrefix -> nodes.any { node -> matchesFastNode(node) }
+
+            is DetectionMethod.NodeStructure -> nodes.any { node ->
+                matchesNode(node, childrenByParentId)
+            }
+
+            is DetectionMethod.AnyOf -> detectionMethods.any { method -> method.matches(nodes, childrenByParentId) }
+
+            is DetectionMethod.AllOf -> detectionMethods.all { method -> method.matches(nodes, childrenByParentId) }
+        }
+    }
+
+    private fun DetectionMethod.NodeStructure.matchesNode(
+        node: DetectionNode,
+        childrenByParentId: Map<Int?, List<DetectionNode>>,
+    ): Boolean {
+        val matchesThisNode = node.isVisible &&
+            node.className in classNames &&
+            node.screenWidthFraction >= minScreenWidthFraction &&
+            node.screenHeightFraction >= minScreenHeightFraction &&
+            (!requireScrollable || node.isScrollable) &&
+            (!requireLongClickable || node.isLongClickable)
+
+        if (!matchesThisNode) return false
+        val requiredDescendant = descendant ?: return true
+        return requiredDescendant.hasMatchingDescendant(node.nodeId, childrenByParentId)
+    }
+
+    private fun DetectionMethod.NodeStructure.hasMatchingDescendant(
+        parentNodeId: Int,
+        childrenByParentId: Map<Int?, List<DetectionNode>>,
+    ): Boolean {
+        return childrenByParentId[parentNodeId].orEmpty().any { child ->
+            matchesNode(child, childrenByParentId) || hasMatchingDescendant(child.nodeId, childrenByParentId)
+        }
+    }
 }


### PR DESCRIPTION
Fixes Facebook Reel detection reported on #169 

Honestly this will probably stop working again in the future because Facebook is developed in a way that makes it the hardest app to detect that its playing Reels.

Will need to think on a more reliable way of knowing when it breaks earlier so that we can fix faster

---- AI Generated Overview:

This pull request introduces a major refactor and extension of the detection logic for blocking content in third-party apps, especially Facebook. The changes move from simple content-description and view-ID based matching to a more robust, structural, and testable approach using a new `DetectionNode` data model and hierarchical matching rules. This enables more accurate detection of complex UI structures (like Facebook Reels) and improves maintainability and testability.

The most important changes are:

**Detection Logic Refactor and Extension**
* Introduced the `DetectionNode` data class to represent a stable, minimal subset of accessibility node properties, decoupling detection logic from Android framework classes and enabling deterministic, testable matching.
* Added the new `DetectionMethod.NodeStructure` detection rule, which allows hierarchical and structural matching of UI trees (e.g., requiring a scrollable list containing a large, long-clickable button, which itself contains a video surface). [[1]](diffhunk://#diff-13117df57a4f86fedb766523bb52cbbf1be83046456d99043b89f90ccf4aeabbL29-R67) [[2]](diffhunk://#diff-13117df57a4f86fedb766523bb52cbbf1be83046456d99043b89f90ccf4aeabbL85-R136)
* Implemented logic in `ResolvedBlockableApp` to recursively match detection nodes against these new structural rules, including support for `AnyOf` and new `AllOf` composite detection methods.

**Facebook Reels Detection Improvements**
* Updated the Facebook `BlockableApp` detection strategy to use the new structural rules, allowing detection of Reels viewers even when accessibility labels vary by language or app version. The detection now covers legacy composer attachment labels, navigation tab prefix matching, and a robust fallback using UI structure. [[1]](diffhunk://#diff-13117df57a4f86fedb766523bb52cbbf1be83046456d99043b89f90ccf4aeabbL71-R108) [[2]](diffhunk://#diff-13117df57a4f86fedb766523bb52cbbf1be83046456d99043b89f90ccf4aeabbL85-R136)

**Accessibility Service Refactoring**
* Refactored `ScrollessBlockAccessibilityService` to use the new detection logic: simple view ID matches are handled directly, while all other detection methods use the new `matchesComplexBlockedContent` method, which builds a hierarchy of `DetectionNode`s and applies the structural matching rules. Old methods for content description and prefix matching were removed or replaced. [[1]](diffhunk://#diff-1639f3e890c9545cc40044792a0bdc82164ce010334ccf694228fdb1d8f2d832L795-R803) [[2]](diffhunk://#diff-1639f3e890c9545cc40044792a0bdc82164ce010334ccf694228fdb1d8f2d832L804-L822) [[3]](diffhunk://#diff-1639f3e890c9545cc40044792a0bdc82164ce010334ccf694228fdb1d8f2d832L840-R886)

These changes make the detection system more robust, flexible, and maintainable, especially for complex and evolving app UIs.

