### PR TITLE
chore: migrate delay() calls to kotlin.time.Duration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -205,6 +205,8 @@ dependencies {
     add("playImplementation", libs.android.review)
     add("playImplementation", libs.android.review.ktx)
 
+    testImplementation(libs.junit)
+
     implementation(projects.core.data)
     implementation(projects.core.designsystem)
     implementation(projects.core.domain)

--- a/app/src/main/java/com/scrolless/app/ui/overlay/TimerOverlayManager.kt
+++ b/app/src/main/java/com/scrolless/app/ui/overlay/TimerOverlayManager.kt
@@ -46,6 +46,7 @@ import com.scrolless.app.designsystem.theme.timerOverlayBackgroundColor
 import com.scrolless.app.designsystem.util.formatAsTime
 import javax.inject.Inject
 import kotlin.math.abs
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -185,7 +186,7 @@ class TimerOverlayManager @Inject constructor(private val userSettingsStore: Use
 
         exitAnimationJob?.cancel()
         exitAnimationJob = coroutineScope.launch {
-            delay(SUMMARY_DISPLAY_DURATION_MS)
+            delay(SUMMARY_DISPLAY_DURATION_MS.milliseconds)
             startExitAnimation()
         }
     }
@@ -226,7 +227,7 @@ class TimerOverlayManager @Inject constructor(private val userSettingsStore: Use
             while (true) {
                 val elapsed = (System.currentTimeMillis() - sessionStartTime).coerceAtLeast(0L)
                 timerTextView?.text = elapsed.formatAsTime()
-                delay(1000)
+                delay(1000.milliseconds)
             }
         }
     }

--- a/feature/home/src/main/java/com/scrolless/app/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/scrolless/app/feature/home/HomeScreen.kt
@@ -131,6 +131,7 @@ import java.time.LocalDateTime
 import java.time.format.TextStyle
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -829,7 +830,7 @@ private fun rememberPauseRemainingTime(pauseUntilMillis: Long): Long {
             while (isActive) {
                 remaining = calculateRemaining()
                 if (remaining <= 0L) break
-                delay(1_000L)
+                delay(1_000L.milliseconds)
             }
         }
     }

--- a/feature/home/src/main/java/com/scrolless/app/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/scrolless/app/feature/home/HomeViewModel.kt
@@ -33,6 +33,7 @@ import java.time.ZonedDateTime
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import kotlin.math.min
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -403,7 +404,7 @@ class HomeViewModel @Inject constructor(
             emit(now.toLocalDate())
             val nextMidnight = now.toLocalDate().plusDays(1).atStartOfDay(now.zone)
             val delayMillis = Duration.between(now, nextMidnight).toMillis().coerceAtLeast(1L)
-            delay(delayMillis)
+            delay(delayMillis.milliseconds)
         }
     }.distinctUntilChanged()
 }


### PR DESCRIPTION
Small cleanup to deal with the Android Studio warnings

Replace millisecond delay(Long) calls with delay(Duration)