### PR TITLE
feat: show total watch time on the timer overlay instead of just the session

### DIFF
--- a/app/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
+++ b/app/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
@@ -606,9 +606,10 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
 
         val blockingSuppressed = isBlockingSuppressed
         serviceScope.launch(Dispatchers.IO) {
-            // If we are not suppressing blocking (it's not paused and user not in DMs), check if we should block when user enters content
-            // If not continue and show overlay timer
-            if (!blockingSuppressed && blockingManager.onEnterBlockedContent()) {
+            // Always call the enter hook so every session has a matching exit hook.
+            // If blocking is suppressed, ignore the hook's blocking result.
+            val shouldBlock = blockingManager.onEnterBlockedContent()
+            if (!blockingSuppressed && shouldBlock) {
                 Timber.i("Blocking on enter")
                 performBackNavigation()
                 return@launch

--- a/app/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
+++ b/app/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
@@ -604,39 +604,59 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
 
         startPeriodicCheck()
 
-        // Only enforce blocking when neither pause nor a content-specific exception is active.
-        if (!isBlockingSuppressed) {
-            serviceScope.launch(Dispatchers.IO) {
+        val blockingSuppressed = isBlockingSuppressed
+        serviceScope.launch(Dispatchers.IO) {
+            if (!blockingSuppressed && blockingManager.onEnterBlockedContent()) {
+                Timber.i("Blocking on enter")
+                performBackNavigation()
+                return@launch
+            }
 
-                val shouldBlock = blockingManager.onEnterBlockedContent()
-                if (shouldBlock) {
-                    Timber.i("Blocking on enter")
-                    performBackNavigation()
-                } else {
-                    // Only show timer overlay if we're NOT blocking immediately
-                    // (no point showing timer if user is about to be kicked out)
-                    mainHandler.post {
-                        if (currentTimerOverlayEnabled && isProcessingBlockedContent) {
-                            Timber.v("Showing timer overlay")
-                            timerOverlayManager.show(session.startedAtMillis)
-                        }
-                    }
-                    Timber.d("Content allowed on enter, will monitor usage")
-                }
+            showTimerOverlayIfEnabled(session)
+
+            if (blockingSuppressed) {
+                Timber.d(
+                    "Skipping blocking check on enter, but tracking usage (paused=%b, suppressed=%b)",
+                    isPauseActive(),
+                    isBlockingSuppressedForCurrentContent,
+                )
+            } else {
+                Timber.d("Content allowed on enter, will monitor usage")
+            }
+        }
+    }
+
+    private suspend fun showTimerOverlayIfEnabled(session: BlockedContentSession) {
+        if (!currentTimerOverlayEnabled) return
+
+        val config = blockingConfigRepository.getConfig()
+        val showOverlay: () -> Unit
+        if (config.activeOption == BlockOption.IntervalTimer) {
+            showOverlay = {
+                timerOverlayManager.showInterval(
+                    sessionStartAt = session.startedAtMillis,
+                    intervalUsage = config.intervalUsage,
+                    intervalLengthMillis = config.settings.intervalLengthMillis,
+                )
             }
         } else {
-            // Paused or blocking-suppressed content still counts as watched time.
-            if (currentTimerOverlayEnabled) {
-                Timber.v("Showing timer overlay (blocking skipped)")
-                mainHandler.post {
-                    timerOverlayManager.show(session.startedAtMillis)
-                }
+            val dailyUsageMillis = sessionTracker.getDailyUsage()
+            showOverlay = {
+                timerOverlayManager.showDaily(
+                    sessionStartAt = session.startedAtMillis,
+                    dailyUsageMillis = dailyUsageMillis,
+                )
             }
-            Timber.d(
-                "Skipping blocking check on enter, but tracking usage (paused=%b, suppressed=%b)",
-                isPauseActive(),
-                isBlockingSuppressedForCurrentContent,
-            )
+        }
+
+        mainHandler.post {
+            if (
+                currentTimerOverlayEnabled &&
+                blockedContentSession?.startedAtMillis == session.startedAtMillis
+            ) {
+                Timber.v("Showing timer overlay")
+                showOverlay()
+            }
         }
     }
 
@@ -674,27 +694,12 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
 
         serviceScope.launch(Dispatchers.IO) {
 
-            // Get total time spent on brainrot to show on the overlay timer before hiding
-            val overlaySummaryTotal = if (currentTimerOverlayEnabled) {
-                val config = blockingConfigRepository.getConfig()
-                when (config.activeOption) {
-                    BlockOption.IntervalTimer -> config.intervalUsage.plusSession(
-                        sessionStartMillis = session.startedAtMillis,
-                        sessionEndMillis = sessionEndMillis,
-                        lengthMillis = config.settings.intervalLengthMillis,
-                    ).usageMillis
-
-                    else -> sessionTracker.getDailyUsage() + sessionTime
-                }
-            } else {
-                null
-            }
-
-            overlaySummaryTotal?.let { total ->
-                mainHandler.post {
-                    Timber.v("Hiding timer overlay")
-                    timerOverlayManager.hide(total, session.startedAtMillis)
-                }
+            mainHandler.post {
+                Timber.v("Hiding timer overlay")
+                timerOverlayManager.hide(
+                    sessionStartAt = session.startedAtMillis,
+                    sessionEndAt = sessionEndMillis,
+                )
             }
 
             // Add to usage in memory with per-app tracking

--- a/app/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
+++ b/app/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
@@ -606,6 +606,8 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
 
         val blockingSuppressed = isBlockingSuppressed
         serviceScope.launch(Dispatchers.IO) {
+            // If we are not suppressing blocking (it's not paused and user not in DMs), check if we should block when user enters content
+            // If not continue and show overlay timer
             if (!blockingSuppressed && blockingManager.onEnterBlockedContent()) {
                 Timber.i("Blocking on enter")
                 performBackNavigation()
@@ -631,6 +633,7 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
 
         val config = blockingConfigRepository.getConfig()
         val showOverlay: () -> Unit
+        // Interval mode shows usage within the active interval; other modes show today's total.
         if (config.activeOption == BlockOption.IntervalTimer) {
             showOverlay = {
                 timerOverlayManager.showInterval(

--- a/app/src/main/java/com/scrolless/app/ui/overlay/TimerOverlayManager.kt
+++ b/app/src/main/java/com/scrolless/app/ui/overlay/TimerOverlayManager.kt
@@ -39,11 +39,13 @@ import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.compose.ui.graphics.toArgb
 import androidx.core.view.WindowInsetsCompat
-import com.scrolless.app.R
+import com.scrolless.app.core.model.IntervalUsage
 import com.scrolless.app.core.repository.UserSettingsStore
 import com.scrolless.app.core.repository.setTimerOverlayPosition
 import com.scrolless.app.designsystem.theme.timerOverlayBackgroundColor
 import com.scrolless.app.designsystem.util.formatAsTime
+import java.time.Instant
+import java.time.ZoneId
 import javax.inject.Inject
 import kotlin.math.abs
 import kotlin.time.Duration.Companion.milliseconds
@@ -58,8 +60,8 @@ import kotlinx.coroutines.launch
 import timber.log.Timber
 
 /**
- * A View-based implementation of TimerOverlayManager.
- * Replaces the Compose-based version to resolve drag lag issues.
+ * A View-based timer overlay that shows saved usage plus the current viewing session.
+ * This uses normal "old" views and not compose because for some reason it the compose version was lagging when dragging
  */
 class TimerOverlayManager @Inject constructor(private val userSettingsStore: UserSettingsStore) {
 
@@ -75,6 +77,8 @@ class TimerOverlayManager @Inject constructor(private val userSettingsStore: Use
     private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
     private var sessionStartTime = 0L
+    private var usage = IntervalUsage.NOT_STARTED
+    private var windowLengthMillis = 0L
     private var timerJob: Job? = null
     private var exitAnimationJob: Job? = null
     private var screenBounds: ScreenBounds? = null
@@ -91,8 +95,28 @@ class TimerOverlayManager @Inject constructor(private val userSettingsStore: Use
         windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
     }
 
+    fun showDaily(sessionStartAt: Long, dailyUsageMillis: Long) {
+        val zoneId = ZoneId.systemDefault()
+        val currentDate = Instant.ofEpochMilli(sessionStartAt).atZone(zoneId).toLocalDate()
+        val dayStartMillis = currentDate.atStartOfDay(zoneId).toInstant().toEpochMilli()
+        val nextDayStartMillis = currentDate.plusDays(1).atStartOfDay(zoneId).toInstant().toEpochMilli()
+
+        // This day length is reused if the overlay remains open for more than one day.
+        // A daylight-saving change during such an unusually long session could make a
+        // later reset one hour early or late. We intentionally ignore that edge case.
+        showOverlay(
+            sessionStartAt = sessionStartAt,
+            usage = IntervalUsage(dayStartMillis, dailyUsageMillis),
+            windowLengthMillis = nextDayStartMillis - dayStartMillis,
+        )
+    }
+
+    fun showInterval(sessionStartAt: Long, intervalUsage: IntervalUsage, intervalLengthMillis: Long) {
+        showOverlay(sessionStartAt, intervalUsage, intervalLengthMillis)
+    }
+
     @SuppressLint("ClickableViewAccessibility")
-    fun show(sessionStartAt: Long = System.currentTimeMillis()) {
+    private fun showOverlay(sessionStartAt: Long, usage: IntervalUsage, windowLengthMillis: Long) {
         if (rootView != null) {
             cleanupView()
         }
@@ -103,10 +127,12 @@ class TimerOverlayManager @Inject constructor(private val userSettingsStore: Use
         val wm = windowManager ?: return
 
         sessionStartTime = sessionStartAt
+        this.usage = usage
+        this.windowLengthMillis = windowLengthMillis
 
         // Create TextView with polished styling
         timerTextView = TextView(serviceContext).apply {
-            text = resources.getText(R.string.timer_default_value)
+            text = displayedDurationAt(System.currentTimeMillis()).formatAsTime()
             textSize = 18f // sp
             typeface = Typeface.DEFAULT_BOLD
             setTextColor(Color.WHITE)
@@ -170,7 +196,7 @@ class TimerOverlayManager @Inject constructor(private val userSettingsStore: Use
         }
     }
 
-    fun hide(summaryTotalMillis: Long, sessionStartAt: Long) {
+    fun hide(sessionStartAt: Long, sessionEndAt: Long) {
 
         Timber.d("Hiding overlay view")
         if (sessionStartTime != sessionStartAt) {
@@ -179,8 +205,9 @@ class TimerOverlayManager @Inject constructor(private val userSettingsStore: Use
         }
 
         timerJob?.cancel()
+        timerJob = null
 
-        timerTextView?.text = summaryTotalMillis.formatAsTime()
+        timerTextView?.text = displayedDurationAt(sessionEndAt).formatAsTime()
 
         startWiggleAnimation()
 
@@ -225,12 +252,17 @@ class TimerOverlayManager @Inject constructor(private val userSettingsStore: Use
         timerJob?.cancel()
         timerJob = coroutineScope.launch {
             while (true) {
-                val elapsed = (System.currentTimeMillis() - sessionStartTime).coerceAtLeast(0L)
-                timerTextView?.text = elapsed.formatAsTime()
+                timerTextView?.text = displayedDurationAt(System.currentTimeMillis()).formatAsTime()
                 delay(1000.milliseconds)
             }
         }
     }
+
+    private fun displayedDurationAt(nowMillis: Long): Long = usage.plusSession(
+        sessionStartMillis = sessionStartTime,
+        sessionEndMillis = nowMillis,
+        lengthMillis = windowLengthMillis,
+    ).usageMillis
 
     private fun startEnterAnimation() {
         val view = rootView ?: return

--- a/app/src/main/java/com/scrolless/app/ui/overlay/TimerOverlayManager.kt
+++ b/app/src/main/java/com/scrolless/app/ui/overlay/TimerOverlayManager.kt
@@ -101,9 +101,9 @@ class TimerOverlayManager @Inject constructor(private val userSettingsStore: Use
         val dayStartMillis = currentDate.atStartOfDay(zoneId).toInstant().toEpochMilli()
         val nextDayStartMillis = currentDate.plusDays(1).atStartOfDay(zoneId).toInstant().toEpochMilli()
 
-        // This day length is reused if the overlay remains open for more than one day.
-        // A daylight-saving change during such an unusually long session could make a
-        // later reset one hour early or late. We intentionally ignore that edge case.
+        // Reset at the next midnight. Edge case: if the overlay stays open for several days
+        // during a daylight-saving clock change, a later reset may be one hour early or late.
+        // But at this point, its the users fault :p
         showOverlay(
             sessionStartAt = sessionStartAt,
             usage = IntervalUsage(dayStartMillis, dailyUsageMillis),

--- a/app/src/main/java/com/scrolless/app/ui/overlay/TimerOverlayManager.kt
+++ b/app/src/main/java/com/scrolless/app/ui/overlay/TimerOverlayManager.kt
@@ -61,7 +61,7 @@ import timber.log.Timber
 
 /**
  * A View-based timer overlay that shows saved usage plus the current viewing session.
- * This uses normal "old" views and not compose because for some reason it the compose version was lagging when dragging
+ * It uses Android Views instead of Compose because the Compose version lagged while dragging.
  */
 class TimerOverlayManager @Inject constructor(private val userSettingsStore: UserSettingsStore) {
 


### PR DESCRIPTION
If the overlay timer shows the total user watch time of the day instead of just the current session start time, it has a bigger impact on the user for them to stop watching. (Except if the user has the Interval Timer option, where it shows total time for the current interval instead.)

-- AI Written Overview: 
**What changes:**
- `TimerOverlayManager.show`/`hide` now take a `UsageWindow` snapshot and derive the displayed duration from it (usage already saved + the running session), instead of being handed a precomputed summary total or defaulting to a plain session-elapsed counter.
- The overlay now restarts at the same point the underlying window does: local midnight for daily limit / no option selected, end of interval for interval timer.
- `ScrollessBlockAccessibilityService` now always starts/exits the session in `BlockingManager`, even when blocking is suppressed (paused, or a content-specific exception like a DM'd reel), so the overlay total stays accurate in those cases too. **Only the back-navigation block itself remains skipped when suppressed** — worth a close look during review since it's a small behavior change beyond the overlay display.