### PR TITLE
chore: enable parallel Gradle sync

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -38,3 +38,5 @@ android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 org.gradle.configuration-cache=true
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true


### PR DESCRIPTION
Enables org.gradle.tooling.parallel=true which lets Gradle 9.4+ run project sync tasks in parallel
(Android Studio suggestion)