### PR TITLE
fix: start interval timer only on first reel or video watch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ fastlane/report.xml
 # Build / local files
 app/release/
 gradle/gradle-daemon-jvm.properties
+.worktrees/

--- a/app/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
+++ b/app/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
@@ -483,10 +483,14 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
         val showOverlay: () -> Unit
         // Interval mode shows usage within the active interval; other modes show today's total.
         if (config.activeOption == BlockOption.IntervalTimer) {
+            val activeInterval = config.intervalUsage.activeIntervalAt(
+                nowMillis = session.startedAtMillis,
+                lengthMillis = config.settings.intervalLengthMillis,
+            )
             showOverlay = {
                 timerOverlayManager.showInterval(
                     sessionStartAt = session.startedAtMillis,
-                    intervalUsage = config.intervalUsage,
+                    intervalUsage = activeInterval,
                     intervalLengthMillis = config.settings.intervalLengthMillis,
                 )
             }

--- a/app/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
+++ b/app/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
@@ -483,14 +483,10 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
         val showOverlay: () -> Unit
         // Interval mode shows usage within the active interval; other modes show today's total.
         if (config.activeOption == BlockOption.IntervalTimer) {
-            val activeInterval = config.intervalUsage.activeIntervalAt(
-                nowMillis = session.startedAtMillis,
-                lengthMillis = config.settings.intervalLengthMillis,
-            )
             showOverlay = {
                 timerOverlayManager.showInterval(
                     sessionStartAt = session.startedAtMillis,
-                    intervalUsage = activeInterval,
+                    intervalUsage = config.intervalUsage,
                     intervalLengthMillis = config.settings.intervalLengthMillis,
                 )
             }

--- a/core/data/src/main/java/com/scrolless/app/core/data/repository/BlockingConfigRepositoryImpl.kt
+++ b/core/data/src/main/java/com/scrolless/app/core/data/repository/BlockingConfigRepositoryImpl.kt
@@ -64,8 +64,8 @@ class BlockingConfigRepositoryImpl @Inject constructor(
         require(allowanceMillis > 0L) { "Interval allowance must be greater than zero" }
         require(intervalLengthMillis > 0L) { "Interval length must be greater than zero" }
 
-        // Roll the window forward with the length it was recorded under before storing the new
-        // one, otherwise lengthening the interval revives an expired window and its usage.
+        // Check if the saved interval is still active with the length it was recorded under.
+        // If expired or not started, save 0L so the timer stays idle until the first video is watched.
         val config = getConfig()
         val current = config.intervalUsage.activeIntervalAt(timeProvider.currentTimeInMillis(), config.settings.intervalLengthMillis)
 

--- a/core/data/src/test/java/com/scrolless/app/core/data/repository/BlockingConfigRepositoryImplTest.kt
+++ b/core/data/src/test/java/com/scrolless/app/core/data/repository/BlockingConfigRepositoryImplTest.kt
@@ -74,13 +74,13 @@ class BlockingConfigRepositoryImplTest {
 
         repository.configureIntervalTimer(allowanceMillis = 2 * MINUTE_MILLIS, intervalLengthMillis = 60 * MINUTE_MILLIS)
 
-        // Rolled forward with the old length first, so the longer interval starts empty instead of
-        // measuring the stale window against it and finding it still running.
+        // Expired window returns NOT_STARTED, so the new interval starts idle at 0L instead of
+        // resurrecting the stale window or synthesizing an artificial ongoing window.
         coVerify(exactly = 1) {
             dao.configureIntervalTimer(
                 allowanceMillis = 2 * MINUTE_MILLIS,
                 intervalLengthMillis = 60 * MINUTE_MILLIS,
-                windowStart = 21_000L,
+                windowStart = 0L,
                 usage = 0L,
             )
         }
@@ -146,7 +146,7 @@ class BlockingConfigRepositoryImplTest {
 
         assertEquals(1_000L, saved.startMillis)
         assertEquals(4_000L, saved.usageMillis)
-        assertEquals(21_000L, saved.activeIntervalAt(nowMillis = 25_000L, lengthMillis = 10_000L).startMillis)
+        assertEquals(0L, saved.activeIntervalAt(nowMillis = 25_000L, lengthMillis = 10_000L).startMillis)
         assertEquals(0L, saved.activeIntervalAt(nowMillis = 25_000L, lengthMillis = 10_000L).usageMillis)
         coVerify(exactly = 0) { dao.updateIntervalState(any(), any()) }
     }

--- a/core/domain/src/main/java/com/scrolless/app/core/blocking/handler/IntervalTimerBlockHandler.kt
+++ b/core/domain/src/main/java/com/scrolless/app/core/blocking/handler/IntervalTimerBlockHandler.kt
@@ -48,7 +48,7 @@ class IntervalTimerBlockHandler(
     /** Includes the session in progress, which is not saved yet, when checking the allowance. */
     override suspend fun onPeriodicCheck(currentDailyUsage: Long, elapsedTime: Long): BlockingResult {
         val now = timeProvider.currentTimeInMillis()
-        val usage = usageAt(now)
+        val usage = blockingConfigRepository.getConfig().intervalUsage
             .plusSession(sessionStartMillis = now - elapsedTime, sessionEndMillis = now, lengthMillis = intervalLengthMillis)
             .usageMillis
 

--- a/core/domain/src/main/java/com/scrolless/app/core/model/IntervalUsage.kt
+++ b/core/domain/src/main/java/com/scrolless/app/core/model/IntervalUsage.kt
@@ -21,14 +21,15 @@ import androidx.compose.runtime.Immutable
 /**
  * Saved usage for an interval timer.
  *
- * For example, a timer starting at 10:00 with a 30-minute length has intervals from 10:00–10:30,
- * 10:30–11:00, and so on. [startMillis] is the start of the last interval saved after a session
- * ended, and [usageMillis] is the time watched during that interval. `0` means the timer has not
- * started.
+ * [startMillis] is the start of the last interval saved after a viewing session ended, and
+ * [usageMillis] is the time watched during that interval. A start of `0` means the timer is idle.
  *
- * Time passing does not update the database by itself. If the saved interval has ended, the
- * functions below calculate the current interval in memory with zero usage. That new interval is
- * saved when the next viewing session ends.
+ * An expired interval stays idle until viewing resumes. For example, if a 30-minute interval ends
+ * at 10:30 and viewing resumes at 10:45, the next interval starts at 10:45. Continuous viewing
+ * across 10:30 starts the next interval at that boundary instead.
+ *
+ * These calculations do not update the database. The interval and its usage are saved when the
+ * viewing session ends.
  */
 @Immutable
 data class IntervalUsage(val startMillis: Long, val usageMillis: Long) {
@@ -43,9 +44,9 @@ data class IntervalUsage(val startMillis: Long, val usageMillis: Long) {
      * interval has ended, returns [NOT_STARTED] so the timer remains idle until the user
      * watches another video.
      *
-     * @return This same [IntervalUsage] instance when the clock moved backwards or the saved
-     * interval is still active. Returns [NOT_STARTED] when the timer has not started, the interval
-     * length is invalid, or the saved interval has elapsed.
+     * @return [NOT_STARTED] when the saved interval has elapsed. Otherwise returns this same
+     * instance, including when the timer has not started, the length is invalid, or the clock
+     * moved backwards.
      */
     fun activeIntervalAt(nowMillis: Long, lengthMillis: Long): IntervalUsage {
         if (!isStarted || lengthMillis <= 0L) return this

--- a/core/domain/src/main/java/com/scrolless/app/core/model/IntervalUsage.kt
+++ b/core/domain/src/main/java/com/scrolless/app/core/model/IntervalUsage.kt
@@ -39,12 +39,13 @@ data class IntervalUsage(val startMillis: Long, val usageMillis: Long) {
     /**
      * Returns the interval active at [nowMillis].
      *
-     * If [nowMillis] is still inside the saved interval, its usage is preserved. If one or more
-     * intervals have ended, the returned value starts at the most recent boundary with zero usage.
+     * If [nowMillis] is still inside the saved interval, its usage is preserved. If the saved
+     * interval has ended, returns [NOT_STARTED] so the timer remains idle until the user
+     * watches another video.
      *
-     * @return This same [IntervalUsage] instance when the timer has not started, the interval length
-     * is invalid, the clock moved backwards, or the saved interval is still active. Otherwise,
-     * returns a new instance for the active interval with zero usage.
+     * @return This same [IntervalUsage] instance when the clock moved backwards or the saved
+     * interval is still active. Returns [NOT_STARTED] when the timer has not started, the interval
+     * length is invalid, or the saved interval has elapsed.
      */
     fun activeIntervalAt(nowMillis: Long, lengthMillis: Long): IntervalUsage {
         if (!isStarted || lengthMillis <= 0L) return this
@@ -63,38 +64,50 @@ data class IntervalUsage(val startMillis: Long, val usageMillis: Long) {
             return this
         }
 
-        val intervalsPassed = elapsedMillis / lengthMillis
-
-        return IntervalUsage(startMillis = startMillis + intervalsPassed * lengthMillis, usageMillis = 0L)
+        return NOT_STARTED
     }
 
-    /** Milliseconds until the interval active at [nowMillis] ends. */
+    /** Milliseconds until the interval active at [nowMillis] ends, or 0 if not running. */
     fun remainingMillisAt(nowMillis: Long, lengthMillis: Long): Long {
         if (!isStarted || lengthMillis <= 0L) return 0L
 
         val current = activeIntervalAt(nowMillis, lengthMillis)
+        if (!current.isStarted) return 0L
 
         return (current.startMillis + lengthMillis - nowMillis).coerceIn(0L, lengthMillis)
     }
 
     /**
-     * Adds the part of a session watched during the interval active at [sessionEndMillis]. If the
-     * session began in an earlier interval, only time watched after the current interval started is
-     * added.
+     * Adds the part of a session watched during the interval active at [sessionEndMillis].
      *
-     * Passing the current time as [sessionEndMillis] gives the usage including a session still in
-     * progress, without having to save it.
+     * If the interval timer has not started or the previous window has already ended, this
+     * session starts a fresh interval anchored at [sessionStartMillis].
+     *
+     * If a session began in an earlier active interval and crossed into the next, only time
+     * watched after the window boundary is counted in the new window.
      */
     fun plusSession(sessionStartMillis: Long, sessionEndMillis: Long, lengthMillis: Long): IntervalUsage {
-        // The first session starts the timer. If the device clock was changed to a time before the
-        // saved interval, move its start to this session so watched time can still be counted, but
-        // preserve the saved usage so changing the clock does not restore the allowance.
-        val schedule = if (!isStarted || sessionEndMillis < startMillis) copy(startMillis = sessionStartMillis) else this
+        if (lengthMillis <= 0L) return this
 
-        val current = schedule.activeIntervalAt(sessionEndMillis, lengthMillis)
-        val watched = sessionEndMillis - maxOf(sessionStartMillis, current.startMillis)
+        // If not started, or if clock moved backwards, or if the previous window ended before this session began:
+        // this session anchors a fresh interval starting at sessionStartMillis.
+        val schedule = if (!isStarted || sessionStartMillis >= startMillis + lengthMillis || sessionEndMillis < startMillis) {
+            val baseUsage = if (isStarted && sessionEndMillis < startMillis) usageMillis else 0L
+            copy(startMillis = sessionStartMillis, usageMillis = baseUsage)
+        } else {
+            this
+        }
 
-        return current.copy(usageMillis = current.usageMillis + watched.coerceAtLeast(0L))
+        val elapsedMillis = sessionEndMillis - schedule.startMillis
+        if (elapsedMillis >= lengthMillis) {
+            val intervalsPassed = elapsedMillis / lengthMillis
+            val newStart = schedule.startMillis + intervalsPassed * lengthMillis
+            val watchedInNewWindow = sessionEndMillis - maxOf(sessionStartMillis, newStart)
+            return IntervalUsage(startMillis = newStart, usageMillis = watchedInNewWindow.coerceAtLeast(0L))
+        }
+
+        val watched = sessionEndMillis - maxOf(sessionStartMillis, schedule.startMillis)
+        return schedule.copy(usageMillis = schedule.usageMillis + watched.coerceAtLeast(0L))
     }
 
     companion object {

--- a/core/domain/src/test/kotlin/com/scrolless/app/core/domain/model/IntervalUsageTest.kt
+++ b/core/domain/src/test/kotlin/com/scrolless/app/core/domain/model/IntervalUsageTest.kt
@@ -34,13 +34,12 @@ class IntervalUsageTest {
     }
 
     @Test
-    fun `a window that ended moves to the interval containing now and clears usage`() {
+    fun `a window that ended expires to not started`() {
         val usage = IntervalUsage(startMillis = 1_000L, usageMillis = 5_000L)
 
         val current = usage.activeIntervalAt(nowMillis = 35_000L, lengthMillis = 10_000L)
 
-        assertEquals(31_000L, current.startMillis)
-        assertEquals(0L, current.usageMillis)
+        assertEquals(IntervalUsage.NOT_STARTED, current)
     }
 
     @Test
@@ -135,17 +134,31 @@ class IntervalUsageTest {
     }
 
     @Test
-    fun `remaining time restarts with the next window instead of staying at zero`() {
+    fun `remaining time becomes zero when the window ends`() {
         val usage = IntervalUsage(startMillis = 1_000L, usageMillis = 0L)
 
         assertEquals(
-            60 * MINUTE_MILLIS,
+            0L,
             usage.remainingMillisAt(nowMillis = 1_000L + 60 * MINUTE_MILLIS, lengthMillis = 60 * MINUTE_MILLIS),
         )
         assertEquals(
-            50 * MINUTE_MILLIS,
+            0L,
             usage.remainingMillisAt(nowMillis = 1_000L + 70 * MINUTE_MILLIS, lengthMillis = 60 * MINUTE_MILLIS),
         )
+    }
+
+    @Test
+    fun `adding a session after an interval expired starts a new window at session start`() {
+        val usage = IntervalUsage(startMillis = 1_000L, usageMillis = 5_000L)
+
+        val updated = usage.plusSession(
+            sessionStartMillis = 35_000L,
+            sessionEndMillis = 37_000L,
+            lengthMillis = 10_000L,
+        )
+
+        assertEquals(35_000L, updated.startMillis)
+        assertEquals(2_000L, updated.usageMillis)
     }
 
     @Test

--- a/feature/home/src/main/java/com/scrolless/app/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/scrolless/app/feature/home/HomeViewModel.kt
@@ -518,10 +518,10 @@ private fun buildUsageAnalyticsDayUiState(date: LocalDate, segments: List<Sessio
 }
 
 /**
- * Emits the window containing the current time, then again every time it restarts.
+ * Emits the active interval window, and once it ends, emits [IntervalUsage.NOT_STARTED] so the screen resets to idle.
  *
  * The stored window is only written when a viewing session ends, but it expires on its own as time
- * passes. Without this, the repository would emit nothing at a restart and the screen would keep
+ * passes. Without this, the repository would emit nothing when the window ends and the screen would keep
  * showing the spent window: usage stuck at the allowance, the progress bar full, and the countdown
  * measured from a start that already passed.
  */
@@ -529,16 +529,16 @@ private fun IntervalUsage.emitOnEveryRestart(lengthMillis: Long): Flow<IntervalU
     var usage = this@emitOnEveryRestart
 
     while (true) {
-        // The stored window may have expired while the screen was closed, so start from the one
-        // running now rather than the one that was last saved.
+        // If the stored window expired while the screen was closed or when its duration ended,
+        // emit the active interval (or NOT_STARTED if expired).
         usage = usage.activeIntervalAt(System.currentTimeMillis(), lengthMillis)
         emit(usage)
 
-        // A timer that never started, or one without a length, has no restart to wait for. Looping
-        // would emit the same value forever without ever suspending.
+        // A timer that never started or has expired has no running window. Stop and wait for
+        // the next video session to start.
         if (!usage.isStarted || lengthMillis <= 0L) return@flow
 
-        // Wake up exactly when this window restarts instead of polling on a fixed tick.
+        // Wake up when this active window ends instead of polling on a fixed tick.
         delay(usage.remainingMillisAt(System.currentTimeMillis(), lengthMillis).milliseconds)
     }
 }

--- a/feature/home/src/main/java/com/scrolless/app/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/scrolless/app/feature/home/HomeViewModel.kt
@@ -161,7 +161,7 @@ class HomeViewModel @Inject constructor(
     /** The blocking config, with its interval window rolled forward to the one running now. */
     private val currentBlockingConfig: Flow<BlockingConfig> = blockingConfigRepository.observeConfig()
         .flatMapLatest { config ->
-            config.intervalUsage.emitOnEveryRestart(config.settings.intervalLengthMillis)
+            config.intervalUsage.emitUntilExpired(config.settings.intervalLengthMillis)
                 .map { usage -> config.copy(intervalUsage = usage) }
         }
         .distinctUntilChanged()
@@ -525,8 +525,8 @@ private fun buildUsageAnalyticsDayUiState(date: LocalDate, segments: List<Sessio
  * showing the spent window: usage stuck at the allowance, the progress bar full, and the countdown
  * measured from a start that already passed.
  */
-private fun IntervalUsage.emitOnEveryRestart(lengthMillis: Long): Flow<IntervalUsage> = flow {
-    var usage = this@emitOnEveryRestart
+private fun IntervalUsage.emitUntilExpired(lengthMillis: Long): Flow<IntervalUsage> = flow {
+    var usage = this@emitUntilExpired
 
     while (true) {
         // If the stored window expired while the screen was closed or when its duration ended,


### PR DESCRIPTION
Interval timer should only start on first reel or video watch instead of continuous running