### PR TITLE
fix: ignore immediately blocked content that counted as 0 sec

### DIFF
--- a/app/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
+++ b/app/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
@@ -541,11 +541,13 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
 
     /** Records viewing time in the session tracker and closes the session with the blocking manager. */
     private suspend fun saveViewing(finished: FinishedViewing) {
-        if (finished.durationMillis > 0L) {
+        if (finished.durationMillis >= MIN_TRACKED_DURATION_MILLIS) {
             sessionTracker.addToDailyUsage(finished.durationMillis, finished.app.app)
+            blockingManager.onExitBlockedContent(finished.startedAtMillis, finished.endedAtMillis)
+        } else {
+            // Sub-second duration (such as content immediately blocked on enter) does not count as viewed content.
+            blockingManager.onExitBlockedContent(finished.startedAtMillis, finished.startedAtMillis)
         }
-        // Even a video blocked immediately must close the session that the manager opened.
-        blockingManager.onExitBlockedContent(finished.startedAtMillis, finished.endedAtMillis)
     }
 
     /** Starts periodic checks to monitor usage limits while content is visible. */
@@ -684,5 +686,8 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
     private companion object {
         /** Default event debounce timeout in ms (matches android:notificationTimeout in accessibility_service_config.xml). */
         const val DEFAULT_NOTIFICATION_TIMEOUT_MS = 250L
+
+        /** Minimum viewing duration required to record usage. Sub-second visits (like immediate blocks) are ignored. */
+        const val MIN_TRACKED_DURATION_MILLIS = 1_000L
     }
 }

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -94,4 +94,6 @@ dependencies {
     implementation(projects.core.data)
     implementation(projects.core.designsystem)
     implementation(projects.core.domain)
+
+    testImplementation(libs.junit)
 }

--- a/feature/home/src/main/java/com/scrolless/app/feature/home/components/ProgressCard.kt
+++ b/feature/home/src/main/java/com/scrolless/app/feature/home/components/ProgressCard.kt
@@ -318,7 +318,7 @@ private fun rememberIntervalRemainingTime(isRunning: Boolean, startMillis: Long,
     return remaining
 }
 
-private fun buildProgressBarSegments(
+internal fun buildProgressBarSegments(
     sessionSegments: List<SessionSegment>,
     currentUsage: Long,
     context: Context,
@@ -333,7 +333,7 @@ private fun buildProgressBarSegments(
 
     return sessionSegments.mapNotNull { segment ->
         val rawUsageMillis = segment.durationMillis.coerceAtLeast(0L)
-        if (rawUsageMillis <= 0L) {
+        if (rawUsageMillis < 1_000L) {
             return@mapNotNull null
         }
         val usageMillis = (rawUsageMillis * scale).toLong().coerceAtLeast(1L)
@@ -346,10 +346,10 @@ private fun buildProgressBarSegments(
     }
 }
 
-private fun buildLegendItems(progressBarSegments: List<ProgressBarSegment>): List<LegendItem> =
+internal fun buildLegendItems(progressBarSegments: List<ProgressBarSegment>): List<LegendItem> =
     progressBarSegments.groupBy { it.segmentName }.mapNotNull { (segmentName, segments) ->
         val totalMillis = segments.sumOf { it.usageMillis.coerceAtLeast(0L) }
-        if (totalMillis <= 0L) {
+        if (totalMillis < 1_000L) {
             return@mapNotNull null
         }
         totalMillis to LegendItem(

--- a/feature/home/src/test/java/com/scrolless/app/feature/home/ProgressCardTest.kt
+++ b/feature/home/src/test/java/com/scrolless/app/feature/home/ProgressCardTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 Scrolless
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.scrolless.app.feature.home
+
+import androidx.compose.ui.graphics.Color
+import com.scrolless.app.designsystem.component.ProgressBarSegment
+import com.scrolless.app.feature.home.components.buildLegendItems
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ProgressCardTest {
+
+    @Test
+    fun `buildLegendItems ignores segments with duration under 1 second`() {
+        val segments = listOf(
+            ProgressBarSegment(segmentName = "TikTok", usageMillis = 50L, color = Color.Black),
+            ProgressBarSegment(segmentName = "YouTube", usageMillis = 500L, color = Color.Red),
+            ProgressBarSegment(segmentName = "Instagram", usageMillis = 999L, color = Color.Magenta),
+        )
+
+        val legendItems = buildLegendItems(segments)
+
+        assertTrue("Expected no legend items for sub-second usage", legendItems.isEmpty())
+    }
+
+    @Test
+    fun `buildLegendItems includes segments with duration of 1 second or more`() {
+        val segments = listOf(
+            ProgressBarSegment(segmentName = "TikTok", usageMillis = 50L, color = Color.Black),
+            ProgressBarSegment(segmentName = "YouTube", usageMillis = 5_000L, color = Color.Red),
+        )
+
+        val legendItems = buildLegendItems(segments)
+
+        assertEquals(1, legendItems.size)
+        assertEquals("YouTube", legendItems.first().legendName)
+        assertEquals("5s", legendItems.first().formattedTime)
+    }
+
+    @Test
+    fun `buildLegendItems aggregates multiple segments for the same app and filters if total under 1 second`() {
+        val subSecondSegments = listOf(
+            ProgressBarSegment(segmentName = "TikTok", usageMillis = 200L, color = Color.Black),
+            ProgressBarSegment(segmentName = "TikTok", usageMillis = 300L, color = Color.Black),
+        )
+        val aboveSecondSegments = listOf(
+            ProgressBarSegment(segmentName = "TikTok", usageMillis = 600L, color = Color.Black),
+            ProgressBarSegment(segmentName = "TikTok", usageMillis = 600L, color = Color.Black),
+        )
+
+        val subSecondLegend = buildLegendItems(subSecondSegments)
+        val aboveSecondLegend = buildLegendItems(aboveSecondSegments)
+
+        assertTrue("Expected TikTok to be omitted when total is under 1 second", subSecondLegend.isEmpty())
+        assertEquals(1, aboveSecondLegend.size)
+        assertEquals("TikTok", aboveSecondLegend.first().legendName)
+        assertEquals("1s", aboveSecondLegend.first().formattedTime)
+    }
+}


### PR DESCRIPTION
Content that was immediately blocked was counted as 0 sec, this commit aims to ignore it