### PR TITLE
feat: enable on-screen timer overlay by default

### DIFF
--- a/app/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
+++ b/app/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
@@ -149,7 +149,7 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
         get() = contentSession?.takeUnless { it.isCovered }
 
     /** Whether the user enabled the floating timer overlay in settings. */
-    private var currentTimerOverlayEnabled: Boolean = false
+    private var currentTimerOverlayEnabled: Boolean = true
 
     /** Whether videos received in direct messages are exempt from blocking. */
     private var currentAllowVideosSentByDm: Boolean = false

--- a/app/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
+++ b/app/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
@@ -149,7 +149,7 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
         get() = contentSession?.takeUnless { it.isCovered }
 
     /** Whether the user enabled the floating timer overlay in settings. */
-    private var currentTimerOverlayEnabled: Boolean = true
+    private var currentTimerOverlayEnabled: Boolean = false
 
     /** Whether videos received in direct messages are exempt from blocking. */
     private var currentAllowVideosSentByDm: Boolean = false

--- a/core/data/src/main/java/com/scrolless/app/core/data/database/model/UserSettingsEntity.kt
+++ b/core/data/src/main/java/com/scrolless/app/core/data/database/model/UserSettingsEntity.kt
@@ -44,7 +44,7 @@ data class UserSettingsEntity(
     @ColumnInfo(name = "interval_length") val intervalLength: Long = 0L,
     @ColumnInfo(name = "interval_window_start_at") val intervalWindowStartAt: Long = 0L,
     @ColumnInfo(name = "interval_usage") val intervalUsage: Long = 0L,
-    @ColumnInfo(name = "timer_overlay_enabled") val timerOverlayEnabled: Boolean,
+    @ColumnInfo(name = "timer_overlay_enabled") val timerOverlayEnabled: Boolean = true,
     @ColumnInfo(name = "timer_overlay_x") val timerOverlayX: Int = 0,
     @ColumnInfo(name = "timer_overlay_y") val timerOverlayY: Int = 100,
     @ColumnInfo(name = "waiting_for_accessibility") val waitingForAccessibility: Boolean = false,

--- a/core/data/src/main/java/com/scrolless/app/core/data/di/DataDiModule.kt
+++ b/core/data/src/main/java/com/scrolless/app/core/data/di/DataDiModule.kt
@@ -87,7 +87,7 @@ object DataDiModule {
                                                    first_launch_at, has_seen_review_prompt,
                                                    review_prompt_attempt_count, review_prompt_last_attempt_at,
                                                    pause_duration_millis, except_reels_sent_by_dm)
-                        VALUES (1, 'NothingSelected', 0, 0, 0, 0, 0, 0, 0, 100, 0, 0, 0,
+                        VALUES (1, 'NothingSelected', 0, 0, 0, 0, 0, 1, 0, 100, 0, 0, 0,
                                 CAST(strftime('%s','now') AS INTEGER) * 1000, 0, 0, 0, 300000, 0)
                         """,
                         )

--- a/core/data/src/main/java/com/scrolless/app/core/data/repository/UserSettingsStoreImpl.kt
+++ b/core/data/src/main/java/com/scrolless/app/core/data/repository/UserSettingsStoreImpl.kt
@@ -37,7 +37,7 @@ class UserSettingsStoreImpl @Inject constructor(private val userSettingsDao: Use
 
     private val coroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
-    private val _timerOverlayEnabled = MutableStateFlow(false)
+    private val _timerOverlayEnabled = MutableStateFlow(true)
     private val _timerOverlayPositionY = MutableStateFlow(0)
     private val _timerOverlayPositionX = MutableStateFlow(0)
     private val _waitingForAccessibility = MutableStateFlow(false)

--- a/core/data/src/main/java/com/scrolless/app/core/data/repository/UserSettingsStoreImpl.kt
+++ b/core/data/src/main/java/com/scrolless/app/core/data/repository/UserSettingsStoreImpl.kt
@@ -37,7 +37,8 @@ class UserSettingsStoreImpl @Inject constructor(private val userSettingsDao: Use
 
     private val coroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
-    private val _timerOverlayEnabled = MutableStateFlow(true)
+    // Wait for the saved preference before allowing the overlay to appear.
+    private val _timerOverlayEnabled = MutableStateFlow(false)
     private val _timerOverlayPositionY = MutableStateFlow(0)
     private val _timerOverlayPositionX = MutableStateFlow(0)
     private val _waitingForAccessibility = MutableStateFlow(false)

--- a/feature/settings/src/main/java/com/scrolless/app/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/scrolless/app/feature/settings/SettingsViewModel.kt
@@ -69,5 +69,5 @@ class SettingsViewModel @Inject constructor(private val userSettingsStore: UserS
 data class SettingsUiState(
     val pauseDurationMinutes: Int = 5,
     val allowVideosSentByDm: Boolean = false,
-    val timerOverlayEnabled: Boolean = false,
+    val timerOverlayEnabled: Boolean = true,
 )


### PR DESCRIPTION
In my opinion the on screen timer is one of the best features to really keep track of the huge amount of time people spend watching reels etc
This commit makes it enabled by default, but users can always deactivate it in the settings