### PR TITLE
Fix TikTok Lite video detection and use player covers

### DIFF
--- a/app/src/main/java/com/scrolless/app/accessibility/ContentCoverDetector.kt
+++ b/app/src/main/java/com/scrolless/app/accessibility/ContentCoverDetector.kt
@@ -49,7 +49,8 @@ internal data class ContentCoverNode(val viewId: String, val bounds: ContentBoun
 
 /** All active cover detectors registered in the app. */
 private val coverDetectors: Map<BlockableApp, ContentCoverDetector> = listOf(
-    TikTokScreenDetector,
+    TikTokScreenDetector(BlockableApp.TIKTOK),
+    TikTokScreenDetector(BlockableApp.TIKTOK_LITE),
     // Add future app cover detectors here (e.g. InstagramScreenDetector)
 ).associateBy { it.app }
 

--- a/app/src/main/java/com/scrolless/app/accessibility/TikTokScreenDetector.kt
+++ b/app/src/main/java/com/scrolless/app/accessibility/TikTokScreenDetector.kt
@@ -18,12 +18,15 @@ package com.scrolless.app.accessibility
 
 import com.scrolless.app.R
 import com.scrolless.app.core.model.BlockableApp
+import com.scrolless.app.core.model.DetectionMethod
 
-/** Covers TikTok's visible player while leaving the rest of the app usable. */
-internal object TikTokScreenDetector : ContentCoverDetector {
-    override val app = BlockableApp.TIKTOK
-    const val PLAYER = "player_view"
-    override val viewIds = setOf(PLAYER)
+/**
+ * Covers the configured player in either TikTok variant while keeping navigation accessible.
+ * Reads the player's ID from the app rule so detection and cover placement use the same target.
+ */
+internal class TikTokScreenDetector(override val app: BlockableApp) : ContentCoverDetector {
+    private val playerViewId = (app.getDetectionMethod() as DetectionMethod.ViewId).viewId
+    override val viewIds = setOf(playerViewId)
     override val titleRes = R.string.tiktok_blocked_title
     override val descriptionRes = R.string.tiktok_blocked_description
 
@@ -34,6 +37,6 @@ internal object TikTokScreenDetector : ContentCoverDetector {
      * as the player view remains at the covered bounds.
      */
     override fun coverBounds(nodes: List<ContentCoverNode>, activeCoverBounds: ContentBounds?): ContentBounds? = nodes.firstOrNull {
-        it.viewId == PLAYER && it.bounds.isVisible && (it.isVisible || it.bounds == activeCoverBounds)
+        it.viewId == playerViewId && it.bounds.isVisible && (it.isVisible || it.bounds == activeCoverBounds)
     }?.bounds
 }

--- a/app/src/test/java/com/scrolless/app/accessibility/ContentCoverTest.kt
+++ b/app/src/test/java/com/scrolless/app/accessibility/ContentCoverTest.kt
@@ -34,12 +34,13 @@ class ContentCoverTest {
     private val cover = ContentCover(ContentCoverTarget.Window(12, 0, bounds), 1, 2)
 
     @Test
-    fun `only TikTok has a cover detector - other apps are unchanged`() {
+    fun `both TikTok variants have cover detectors - other apps are unchanged`() {
         BlockableApp.entries.forEach { app ->
             val resolved = ResolvedBlockableApp(app, app.getPackageIds().first())
-            if (app == BlockableApp.TIKTOK) {
-                assertSame(TikTokScreenDetector, app.coverDetector)
-                assertSame(TikTokScreenDetector, resolved.coverDetector)
+            if (app in setOf(BlockableApp.TIKTOK, BlockableApp.TIKTOK_LITE)) {
+                assertNotNull(app.coverDetector)
+                assertEquals(app, app.coverDetector!!.app)
+                assertSame(app.coverDetector, resolved.coverDetector)
             } else {
                 assertNull(app.coverDetector)
                 assertNull(resolved.coverDetector)

--- a/app/src/test/java/com/scrolless/app/accessibility/TikTokScreenDetectorTest.kt
+++ b/app/src/test/java/com/scrolless/app/accessibility/TikTokScreenDetectorTest.kt
@@ -16,6 +16,7 @@
  */
 package com.scrolless.app.accessibility
 
+import com.scrolless.app.core.model.BlockableApp
 import javax.xml.parsers.DocumentBuilderFactory
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -23,48 +24,63 @@ import org.junit.Test
 import org.w3c.dom.Element
 
 class TikTokScreenDetectorTest {
+    private val detector = TikTokScreenDetector(BlockableApp.TIKTOK)
+
     @Test
     fun `captured feed covers the player but not native navigation`() {
-        assertEquals(ContentBounds(0, 0, 1080, 2160), TikTokScreenDetector.coverBounds(fixture("home")))
+        assertEquals(ContentBounds(0, 0, 1080, 2160), detector.coverBounds(fixture("home")))
     }
 
     @Test
     fun `captured DM video covers the player correctly`() {
-        assertEquals(ContentBounds(0, 97, 1080, 2160), TikTokScreenDetector.coverBounds(fixture("dm_video")))
+        assertEquals(ContentBounds(0, 97, 1080, 2160), detector.coverBounds(fixture("dm_video")))
     }
 
     @Test
     fun `captured Inbox contains no blockable video`() {
-        assertNull(TikTokScreenDetector.coverBounds(fixture("inbox")))
+        assertNull(detector.coverBounds(fixture("inbox")))
     }
 
     @Test
     fun `invisible players are not covered without active cover`() {
         val nodes = fixture("home").map {
-            if (it.viewId == TikTokScreenDetector.PLAYER) it.copy(isVisible = false) else it
+            if (it.viewId == "player_view") it.copy(isVisible = false) else it
         }
-        assertNull(TikTokScreenDetector.coverBounds(nodes))
+        assertNull(detector.coverBounds(nodes))
     }
 
     @Test
     fun `invisible player occluded by active cover remains covered`() {
-        val player = fixture("home").first { it.viewId == TikTokScreenDetector.PLAYER }
+        val player = fixture("home").first { it.viewId == "player_view" }
         val nodes = fixture("home").map {
-            if (it.viewId == TikTokScreenDetector.PLAYER) it.copy(isVisible = false) else it
+            if (it.viewId == "player_view") it.copy(isVisible = false) else it
         }
-        assertEquals(player.bounds, TikTokScreenDetector.coverBounds(nodes, activeCoverBounds = player.bounds))
+        assertEquals(player.bounds, detector.coverBounds(nodes, activeCoverBounds = player.bounds))
     }
 
     @Test
     fun `offscreen empty players do not match`() {
         val nodes = listOf(ContentCoverNode("player_view", ContentBounds(0, 2160, 1080, 2160), true))
-        assertNull(TikTokScreenDetector.coverBounds(nodes))
+        assertNull(detector.coverBounds(nodes))
     }
 
     @Test
     fun `visible videos opened from a native tab still get detected`() {
-        val player = fixture("home").first { it.viewId == TikTokScreenDetector.PLAYER }
-        assertEquals(player.bounds, TikTokScreenDetector.coverBounds(fixture("inbox") + player))
+        val player = fixture("home").first { it.viewId == "player_view" }
+        assertEquals(player.bounds, detector.coverBounds(fixture("inbox") + player))
+    }
+
+    /** Verifies Lite uses its own player bounds and keeps the cover when it obscures that player. */
+    @Test
+    fun `Lite covers its player without matching the regular TikTok ID`() {
+        val lite = TikTokScreenDetector(BlockableApp.TIKTOK_LITE)
+        val bounds = ContentBounds(0, 97, 1080, 2160)
+        val player = ContentCoverNode("simplayer_api_player_view", bounds, true)
+        assertEquals(bounds, lite.coverBounds(listOf(player)))
+        assertEquals(bounds, lite.coverBounds(listOf(player.copy(isVisible = false)), bounds))
+        assertNull(lite.coverBounds(listOf(player.copy(isVisible = false))))
+        assertNull(lite.coverBounds(listOf(player.copy(viewId = "player_view"))))
+        assertNull(lite.coverBounds(emptyList(), bounds))
     }
 
     private fun fixture(name: String): List<ContentCoverNode> {

--- a/app/src/test/java/com/scrolless/app/ui/overlay/ContentCoverTargetTest.kt
+++ b/app/src/test/java/com/scrolless/app/ui/overlay/ContentCoverTargetTest.kt
@@ -19,6 +19,7 @@ package com.scrolless.app.ui.overlay
 import com.scrolless.app.accessibility.ContentBounds
 import com.scrolless.app.accessibility.ContentCoverNode
 import com.scrolless.app.accessibility.TikTokScreenDetector
+import com.scrolless.app.core.model.BlockableApp
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -61,8 +62,8 @@ class ContentCoverTargetTest {
     @Test
     fun `window local player bounds are used directly as the cover target`() {
         val localPlayer = ContentBounds(0, 0, 800, 1400)
-        val nodes = listOf(ContentCoverNode(TikTokScreenDetector.PLAYER, localPlayer, true))
-        val target = window.copy(bounds = TikTokScreenDetector.coverBounds(nodes)!!)
+        val nodes = listOf(ContentCoverNode("player_view", localPlayer, true))
+        val target = window.copy(bounds = TikTokScreenDetector(BlockableApp.TIKTOK).coverBounds(nodes)!!)
         assertEquals(localPlayer, target.bounds)
     }
 }

--- a/core/domain/src/main/java/com/scrolless/app/core/model/BlockableApp.kt
+++ b/core/domain/src/main/java/com/scrolless/app/core/model/BlockableApp.kt
@@ -17,7 +17,6 @@
 package com.scrolless.app.core.model
 
 import android.accessibilityservice.AccessibilityService.GLOBAL_ACTION_BACK
-import android.accessibilityservice.AccessibilityService.GLOBAL_ACTION_HOME
 import androidx.compose.runtime.Immutable
 
 /**
@@ -162,7 +161,6 @@ enum class BlockableApp(
             "com.zhiliaoapp.musically",
             "com.ss.android.ugc.trill",
             "com.ss.android.ugc.aweme",
-            "com.zhiliaoapp.musically.go",
         ),
         detectionMethod = DetectionMethod.ViewId("player_view"),
         blockAction = ContentBlockAction.CoverVideoRegion,
@@ -173,8 +171,9 @@ enum class BlockableApp(
     ),
     TIKTOK_LITE(
         packageIds = listOf("com.zhiliaoapp.musically.go"),
-        detectionMethod = DetectionMethod.ViewId("h89"),
-        blockAction = ContentBlockAction.PerformGlobalAction(GLOBAL_ACTION_HOME),
+        // Target the named player view so obfuscated container-ID changes do not break detection.
+        detectionMethod = DetectionMethod.ViewId("simplayer_api_player_view"),
+        blockAction = ContentBlockAction.CoverVideoRegion,
     ),
     FACEBOOK(
         packageIds = listOf("com.facebook.katana"),

--- a/core/domain/src/main/java/com/scrolless/app/core/model/BlockableApp.kt
+++ b/core/domain/src/main/java/com/scrolless/app/core/model/BlockableApp.kt
@@ -171,7 +171,6 @@ enum class BlockableApp(
     ),
     TIKTOK_LITE(
         packageIds = listOf("com.zhiliaoapp.musically.go"),
-        // Target the named player view so obfuscated container-ID changes do not break detection.
         detectionMethod = DetectionMethod.ViewId("simplayer_api_player_view"),
         blockAction = ContentBlockAction.CoverVideoRegion,
     ),

--- a/core/domain/src/test/kotlin/com/scrolless/app/core/domain/model/ContentBlockActionTest.kt
+++ b/core/domain/src/test/kotlin/com/scrolless/app/core/domain/model/ContentBlockActionTest.kt
@@ -17,23 +17,40 @@
 package com.scrolless.app.core.domain.model
 
 import android.accessibilityservice.AccessibilityService.GLOBAL_ACTION_BACK
-import android.accessibilityservice.AccessibilityService.GLOBAL_ACTION_HOME
 import com.scrolless.app.core.model.BlockableApp
 import com.scrolless.app.core.model.ContentBlockAction
+import com.scrolless.app.core.model.DetectionNode
+import com.scrolless.app.core.model.ResolvedBlockableApp
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ContentBlockActionTest {
     @Test
-    fun `regular TikTok covers its video without leaving the app`() {
-        assertEquals(ContentBlockAction.CoverVideoRegion, BlockableApp.TIKTOK.getBlockAction())
+    fun `both TikTok variants cover their videos without leaving the app`() {
+        for (app in listOf(BlockableApp.TIKTOK, BlockableApp.TIKTOK_LITE)) {
+            assertEquals(ContentBlockAction.CoverVideoRegion, app.getBlockAction())
+        }
     }
 
     @Test
     fun `other apps retain their existing navigation action`() {
-        for (app in BlockableApp.entries.filter { it != BlockableApp.TIKTOK }) {
-            val action = if (app == BlockableApp.TIKTOK_LITE) GLOBAL_ACTION_HOME else GLOBAL_ACTION_BACK
-            assertEquals(ContentBlockAction.PerformGlobalAction(action), app.getBlockAction())
+        for (app in BlockableApp.entries.filter { it !in setOf(BlockableApp.TIKTOK, BlockableApp.TIKTOK_LITE) }) {
+            assertEquals(ContentBlockAction.PerformGlobalAction(GLOBAL_ACTION_BACK), app.getBlockAction())
         }
+    }
+
+    /** Keeps Lite on its own rule and rejects hidden players left behind when opening a native tab. */
+    @Test
+    fun `TikTok Lite resolves to its own visible player rule`() {
+        val packageId = "com.zhiliaoapp.musically.go"
+        val matches = BlockableApp.entries.filter { it.resolvePackage(packageId) != null }
+        assertEquals(listOf(BlockableApp.TIKTOK_LITE), matches)
+        val app = ResolvedBlockableApp(matches.single(), packageId)
+        val player = DetectionNode(nodeId = 1, viewId = "$packageId:id/simplayer_api_player_view")
+        assertTrue(app.matchesFastDetectionNode(player))
+        assertFalse(app.matchesFastDetectionNode(player.copy(isVisible = false)))
+        assertFalse(app.matchesFastDetectionNode(player.copy(viewId = "$packageId:id/player_view")))
     }
 }

--- a/feature/settings/src/main/java/com/scrolless/app/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/scrolless/app/feature/settings/SettingsScreen.kt
@@ -307,6 +307,7 @@ private fun AllowVideosSentByDmItem(checked: Boolean, onCheckedChange: (Boolean)
     SettingsSwitchItem(
         title = stringResource(R.string.settings_allow_videos_sent_by_dms_title),
         description = stringResource(R.string.settings_allow_videos_sent_by_dms_description),
+        note = stringResource(R.string.settings_allow_videos_sent_by_dms_note),
         checked = checked,
         onCheckedChange = onCheckedChange,
         modifier = modifier,
@@ -324,6 +325,7 @@ private fun TimerOverlayItem(checked: Boolean, onCheckedChange: (Boolean) -> Uni
     )
 }
 
+/** Shows a toggle with its description and an optional smaller note for feature limitations. */
 @Composable
 private fun SettingsSwitchItem(
     title: String,
@@ -331,6 +333,7 @@ private fun SettingsSwitchItem(
     checked: Boolean,
     onCheckedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
+    note: String? = null,
 ) {
     val hapticHelper = rememberHapticHelper()
     Row(
@@ -354,6 +357,13 @@ private fun SettingsSwitchItem(
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+            if (note != null) {
+                Text(
+                    text = note,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         }
         Switch(
             checked = checked,

--- a/feature/settings/src/main/res/values-b+sr+Latn/strings.xml
+++ b/feature/settings/src/main/res/values-b+sr+Latn/strings.xml
@@ -27,6 +27,7 @@
         <item quantity="other">%1$d minuta</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">Ne blokiraj video snimke poslate u DM-ovima.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">Nije podržano u aplikaciji TikTok Lite</string>
     <string name="settings_allow_videos_sent_by_dms_title">Video snimci poslati u DM-ovima</string>
     <string name="settings_show_onscreen_timer_description">Drži plutajući tajmer vidljivim dok gledaš kratke video-zapise.</string>
     <string name="settings_show_onscreen_timer_title">Prikaži tajmer na ekranu</string>

--- a/feature/settings/src/main/res/values-ca/strings.xml
+++ b/feature/settings/src/main/res/values-ca/strings.xml
@@ -26,6 +26,7 @@
         <item quantity="other">%1$d minuts</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">No bloquis els vídeos enviats per missatges directes.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">No és compatible amb TikTok Lite</string>
     <string name="settings_allow_videos_sent_by_dms_title">Vídeos enviats per missatges directes</string>
     <string name="settings_show_onscreen_timer_description">Mantén visible un temporitzador flotant mentre mires vídeos curts.</string>
     <string name="settings_show_onscreen_timer_title">Mostra el temporitzador a la pantalla</string>

--- a/feature/settings/src/main/res/values-cs/strings.xml
+++ b/feature/settings/src/main/res/values-cs/strings.xml
@@ -28,6 +28,7 @@
         <item quantity="other">%1$d minut</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">Neblokovat videa odeslaná v DMs.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">TikTok Lite tuto funkci nepodporuje</string>
     <string name="settings_allow_videos_sent_by_dms_title">Videa odeslaná v DMs</string>
     <string name="settings_show_onscreen_timer_description">Při sledování krátkých videí ponechat viditelný plovoucí časovač.</string>
     <string name="settings_show_onscreen_timer_title">Zobrazit časovač na obrazovce</string>

--- a/feature/settings/src/main/res/values-de/strings.xml
+++ b/feature/settings/src/main/res/values-de/strings.xml
@@ -26,6 +26,7 @@
         <item quantity="one">%1$d Minute</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">Videos, die in DMs gesendet wurden, nicht blockieren.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">Wird in TikTok Lite nicht unterstützt</string>
     <string name="settings_allow_videos_sent_by_dms_title">In DMs gesendete Videos</string>
     <string name="settings_show_onscreen_timer_description">Beim Ansehen von Kurzvideos einen schwebenden Timer sichtbar lassen.</string>
     <string name="settings_show_onscreen_timer_title">Bildschirmtimer anzeigen</string>

--- a/feature/settings/src/main/res/values-el/strings.xml
+++ b/feature/settings/src/main/res/values-el/strings.xml
@@ -26,6 +26,7 @@
         <item quantity="one">%1$d λεπτό</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">Να μην αποκλείονται τα βίντεο που αποστέλλονται σε DM.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">Δεν υποστηρίζεται στο TikTok Lite</string>
     <string name="settings_allow_videos_sent_by_dms_title">Βίντεο που αποστέλλονται σε DM</string>
     <string name="settings_show_onscreen_timer_description">Να εμφανίζεται ένας αιωρούμενος χρονοδιακόπτης κατά την παρακολούθηση σύντομων βίντεο.</string>
     <string name="settings_show_onscreen_timer_title">Εμφάνιση χρονοδιακόπτη στην οθόνη</string>

--- a/feature/settings/src/main/res/values-es/strings.xml
+++ b/feature/settings/src/main/res/values-es/strings.xml
@@ -26,6 +26,7 @@
         <item quantity="other">%1$d minutos</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">No bloquear los vídeos enviados en mensajes directos.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">No es compatible con TikTok Lite</string>
     <string name="settings_allow_videos_sent_by_dms_title">Vídeos enviados en mensajes directos</string>
     <string name="settings_show_onscreen_timer_description">Mantén visible un temporizador flotante mientras ves vídeos cortos.</string>
     <string name="settings_show_onscreen_timer_title">Mostrar temporizador en pantalla</string>

--- a/feature/settings/src/main/res/values-fi-rFI/strings.xml
+++ b/feature/settings/src/main/res/values-fi-rFI/strings.xml
@@ -26,6 +26,7 @@
         <item quantity="one">%1$d minuutti</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">Älä estä DM-viesteissä lähetettyjä videoita.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">Ei tueta TikTok Litessä</string>
     <string name="settings_allow_videos_sent_by_dms_title">DM-viesteissä lähetetyt videot</string>
     <string name="settings_show_onscreen_timer_description">Pidä kelluva ajastin näkyvissä, kun katsot lyhytvideoita.</string>
     <string name="settings_show_onscreen_timer_title">Näytä ajastin näytöllä</string>

--- a/feature/settings/src/main/res/values-fr/strings.xml
+++ b/feature/settings/src/main/res/values-fr/strings.xml
@@ -26,6 +26,7 @@
         <item quantity="other">%1$d minutes</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">Ne pas bloquer les vidéos envoyées par messages directs.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">Non pris en charge sur TikTok Lite</string>
     <string name="settings_allow_videos_sent_by_dms_title">Vidéos envoyées par messages directs</string>
     <string name="settings_show_onscreen_timer_description">Garder un minuteur flottant visible en regardant des vidéos courtes.</string>
     <string name="settings_show_onscreen_timer_title">Afficher le minuteur à l\'écran</string>

--- a/feature/settings/src/main/res/values-hi/strings.xml
+++ b/feature/settings/src/main/res/values-hi/strings.xml
@@ -26,6 +26,7 @@
         <item quantity="one">%1$d मिनट</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">DMs में भेजे गए वीडियो को ब्लॉक न करें।</string>
+    <string name="settings_allow_videos_sent_by_dms_note">TikTok Lite में यह सुविधा उपलब्ध नहीं है</string>
     <string name="settings_allow_videos_sent_by_dms_title">DMs में भेजे गए वीडियो</string>
     <string name="settings_show_onscreen_timer_description">छोटे वीडियो देखते समय एक फ़्लोटिंग टाइमर दृश्यमान रखें।</string>
     <string name="settings_show_onscreen_timer_title">ऑन-स्क्रीन टाइमर दिखाएँ</string>

--- a/feature/settings/src/main/res/values-hr/strings.xml
+++ b/feature/settings/src/main/res/values-hr/strings.xml
@@ -27,6 +27,7 @@
         <item quantity="few">%1$d minute</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">Ne blokiraj videozapise poslane u DM-ovima.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">Nije podržano u aplikaciji TikTok Lite</string>
     <string name="settings_allow_videos_sent_by_dms_title">Videozapisi poslani u DM-ovima</string>
     <string name="settings_show_onscreen_timer_description">Zadrži plutajući mjerač vremena vidljivim dok gledaš kratke videozapise.</string>
     <string name="settings_show_onscreen_timer_title">Prikaži mjerač vremena na zaslonu</string>

--- a/feature/settings/src/main/res/values-hu/strings.xml
+++ b/feature/settings/src/main/res/values-hu/strings.xml
@@ -26,6 +26,7 @@
         <item quantity="one">%1$d perc</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">Ne blokkolja a DM-ben küldött videókat.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">A TikTok Lite nem támogatott</string>
     <string name="settings_allow_videos_sent_by_dms_title">DM-ben küldött videók</string>
     <string name="settings_show_onscreen_timer_description">Tartsa láthatóan a lebegő időzítőt rövid videók nézése közben.</string>
     <string name="settings_show_onscreen_timer_title">Képernyőn megjelenő időzítő</string>

--- a/feature/settings/src/main/res/values-it/strings.xml
+++ b/feature/settings/src/main/res/values-it/strings.xml
@@ -26,6 +26,7 @@
         <item quantity="other">%1$d minuti</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">Non bloccare i video inviati nei messaggi diretti.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">Non supportato su TikTok Lite</string>
     <string name="settings_allow_videos_sent_by_dms_title">Video inviati nei messaggi diretti</string>
     <string name="settings_show_onscreen_timer_description">Mantieni un timer mobile visibile mentre guardi contenuti brevi.</string>
     <string name="settings_show_onscreen_timer_title">Mostra timer sullo schermo</string>

--- a/feature/settings/src/main/res/values-ja/strings.xml
+++ b/feature/settings/src/main/res/values-ja/strings.xml
@@ -25,6 +25,7 @@
         <item quantity="other">%1$d分</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">DMで送られた動画はブロックしません。</string>
+    <string name="settings_allow_videos_sent_by_dms_note">TikTok Liteには対応していません</string>
     <string name="settings_allow_videos_sent_by_dms_title">DMで送られた動画</string>
     <string name="settings_show_onscreen_timer_description">ショート動画を視聴中にフローティングタイマーを表示します。</string>
     <string name="settings_show_onscreen_timer_title">画面タイマーを表示</string>

--- a/feature/settings/src/main/res/values-ml/strings.xml
+++ b/feature/settings/src/main/res/values-ml/strings.xml
@@ -26,6 +26,7 @@
         <item quantity="one">%1$d മിനിറ്റ്</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">DM-കളിൽ അയച്ച വീഡിയോകൾ ബ്ലോക്ക് ചെയ്യരുത്.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">TikTok Lite-ൽ ഈ സൗകര്യം പിന്തുണയ്ക്കുന്നില്ല</string>
     <string name="settings_allow_videos_sent_by_dms_title">DM-കളിൽ അയച്ച വീഡിയോകൾ</string>
     <string name="settings_show_onscreen_timer_description">ചെറിയ വീഡിയോകൾ കാണുമ്പോൾ ഒരു ഫ്ലോട്ടിംഗ് ടൈമർ ദൃശ്യമാക്കി നിർത്തുക.</string>
     <string name="settings_show_onscreen_timer_title">ഓൺ-സ്ക്രീൻ ടൈമർ കാണിക്കുക</string>

--- a/feature/settings/src/main/res/values-mr/strings.xml
+++ b/feature/settings/src/main/res/values-mr/strings.xml
@@ -26,6 +26,7 @@
         <item quantity="one">%1$d मिनिट</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">DMs मध्ये पाठवलेले व्हिडिओ ब्लॉक करू नका.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">TikTok Lite मध्ये हे वैशिष्ट्य समर्थित नाही</string>
     <string name="settings_allow_videos_sent_by_dms_title">DMs मध्ये पाठवलेले व्हिडिओ</string>
     <string name="settings_show_onscreen_timer_description">लहान व्हिडिओ पाहताना फ्लोटिंग टाइमर दृश्यमान ठेवा.</string>
     <string name="settings_show_onscreen_timer_title">ऑन-स्क्रीन टाइमर दाखवा</string>

--- a/feature/settings/src/main/res/values-nb-rNO/strings.xml
+++ b/feature/settings/src/main/res/values-nb-rNO/strings.xml
@@ -26,6 +26,7 @@
         <item quantity="one">%1$d minutt</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">Ikke blokker videoer sendt i DM-er.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">Støttes ikke i TikTok Lite</string>
     <string name="settings_allow_videos_sent_by_dms_title">Videoer sendt i DM-er</string>
     <string name="settings_show_onscreen_timer_description">Hold en flytende tidtaker synlig mens du ser på korte videoer.</string>
     <string name="settings_show_onscreen_timer_title">Vis tidtaker på skjermen</string>

--- a/feature/settings/src/main/res/values-nl/strings.xml
+++ b/feature/settings/src/main/res/values-nl/strings.xml
@@ -26,6 +26,7 @@
         <item quantity="other">%1$d minuten</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">Blokkeer geen video\'s die via DM\'s zijn verzonden.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">Niet ondersteund in TikTok Lite</string>
     <string name="settings_allow_videos_sent_by_dms_title">Video\'s verzonden via DM\'s</string>
     <string name="settings_show_onscreen_timer_description">Houd een zwevende timer zichtbaar tijdens het bekijken van korte video\'s.</string>
     <string name="settings_show_onscreen_timer_title">Toon timer op scherm</string>

--- a/feature/settings/src/main/res/values-nn-rNO/strings.xml
+++ b/feature/settings/src/main/res/values-nn-rNO/strings.xml
@@ -26,6 +26,7 @@
         <item quantity="other">%1$d minuttar</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">Ikkje blokker videoar sende i DM-ar.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">Ikkje støtta i TikTok Lite</string>
     <string name="settings_allow_videos_sent_by_dms_title">Videoar sende i DM-ar</string>
     <string name="settings_show_onscreen_timer_description">Hald ein flytande tidtakar synleg medan du ser på korte videoar.</string>
     <string name="settings_show_onscreen_timer_title">Vis tidtakar på skjermen</string>

--- a/feature/settings/src/main/res/values-pl/strings.xml
+++ b/feature/settings/src/main/res/values-pl/strings.xml
@@ -28,6 +28,7 @@
         <item quantity="other">%1$d minuty</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">Nie blokuj filmów wysyłanych w wiadomościach prywatnych.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">Ta funkcja nie jest obsługiwana w TikTok Lite</string>
     <string name="settings_allow_videos_sent_by_dms_title">Filmy wysyłane w wiadomościach prywatnych</string>
     <string name="settings_show_onscreen_timer_description">Utrzymuj widoczny pływający minutnik podczas oglądania krótkich filmów.</string>
     <string name="settings_show_onscreen_timer_title">Pokaż minutnik na ekranie</string>

--- a/feature/settings/src/main/res/values-pt-rBR/strings.xml
+++ b/feature/settings/src/main/res/values-pt-rBR/strings.xml
@@ -26,6 +26,7 @@
         <item quantity="one">%1$d minuto</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">Não bloquear vídeos enviados em DMs.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">Não disponível no TikTok Lite</string>
     <string name="settings_allow_videos_sent_by_dms_title">Vídeos enviados em DMs</string>
     <string name="settings_show_onscreen_timer_description">Manter um timer flutuante visível enquanto você assiste a vídeos curtos.</string>
     <string name="settings_show_onscreen_timer_title">Mostrar timer na tela</string>

--- a/feature/settings/src/main/res/values-pt/strings.xml
+++ b/feature/settings/src/main/res/values-pt/strings.xml
@@ -26,6 +26,7 @@
         <item quantity="one">%1$d minuto</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">Não bloquear vídeos enviados em DMs.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">Não disponível no TikTok Lite</string>
     <string name="settings_allow_videos_sent_by_dms_title">Vídeos enviados em DMs</string>
     <string name="settings_show_onscreen_timer_description">Mantenha um temporizador flutuante visível enquanto vê vídeos curtos.</string>
     <string name="settings_show_onscreen_timer_title">Mostrar temporizador no ecrã</string>

--- a/feature/settings/src/main/res/values-ro/strings.xml
+++ b/feature/settings/src/main/res/values-ro/strings.xml
@@ -27,6 +27,7 @@
         <item quantity="few">%1$d minute</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">Nu bloca videoclipurile trimise în mesaje directe.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">Funcția nu este disponibilă în TikTok Lite</string>
     <string name="settings_allow_videos_sent_by_dms_title">Videoclipuri trimise în mesaje directe</string>
     <string name="settings_show_onscreen_timer_description">Păstrează un cronometru plutitor vizibil în timp ce vizionezi videoclipuri scurte.</string>
     <string name="settings_show_onscreen_timer_title">Afișează cronometrul pe ecran</string>

--- a/feature/settings/src/main/res/values-ru/strings.xml
+++ b/feature/settings/src/main/res/values-ru/strings.xml
@@ -28,6 +28,7 @@
         <item quantity="other">%1$d минут</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">Не блокировать видео, отправленные в личных сообщениях.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">Не поддерживается в TikTok Lite</string>
     <string name="settings_allow_videos_sent_by_dms_title">Видео, отправленные в личных сообщениях</string>
     <string name="settings_show_onscreen_timer_description">Отображать плавающий таймер во время просмотра коротких видео.</string>
     <string name="settings_show_onscreen_timer_title">Показывать таймер на экране</string>

--- a/feature/settings/src/main/res/values-sk-rSK/strings.xml
+++ b/feature/settings/src/main/res/values-sk-rSK/strings.xml
@@ -28,6 +28,7 @@
         <item quantity="one">%1$d minúta</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">Neblokovať videá odoslané v DM.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">TikTok Lite túto funkciu nepodporuje</string>
     <string name="settings_allow_videos_sent_by_dms_title">Videá odoslané v DM</string>
     <string name="settings_show_onscreen_timer_description">Ponechať plávajúci časovač viditeľný pri sledovaní krátkych videí.</string>
     <string name="settings_show_onscreen_timer_title">Zobraziť časovač na obrazovke</string>

--- a/feature/settings/src/main/res/values-sr/strings.xml
+++ b/feature/settings/src/main/res/values-sr/strings.xml
@@ -27,6 +27,7 @@
         <item quantity="other">%1$d минута</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">Не блокирај видео снимке послате у DM-овима.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">Није подржано у апликацији TikTok Lite</string>
     <string name="settings_allow_videos_sent_by_dms_title">Видео снимци послати у DM-овима</string>
     <string name="settings_show_onscreen_timer_description">Држи плутајући тајмер видљивим док гледаш кратке видео-записе.</string>
     <string name="settings_show_onscreen_timer_title">Прикажи тајмер на екрану</string>

--- a/feature/settings/src/main/res/values-sv-rSE/strings.xml
+++ b/feature/settings/src/main/res/values-sv-rSE/strings.xml
@@ -26,6 +26,7 @@
         <item quantity="one">%1$d minut</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">Blockera inte videor som skickats i DM.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">Stöds inte i TikTok Lite</string>
     <string name="settings_allow_videos_sent_by_dms_title">Videor skickade i DM</string>
     <string name="settings_show_onscreen_timer_description">Håll en flytande timer synlig när du tittar på kort videoinnehåll.</string>
     <string name="settings_show_onscreen_timer_title">Visa timer på skärmen</string>

--- a/feature/settings/src/main/res/values-ta-rIN/strings.xml
+++ b/feature/settings/src/main/res/values-ta-rIN/strings.xml
@@ -26,6 +26,7 @@
         <item quantity="other">%1$d நிமிடங்கள்</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">நேரடிச் செய்திகளில் அனுப்பப்பட்ட வீடியோக்களைத் தடுக்க வேண்டாம்.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">TikTok Lite இல் இந்த அம்சம் ஆதரிக்கப்படவில்லை</string>
     <string name="settings_allow_videos_sent_by_dms_title">நேரடிச் செய்திகளில் அனுப்பப்பட்ட வீடியோக்கள்</string>
     <string name="settings_show_onscreen_timer_description">குறுகிய வீடியோக்களைப் பார்க்கும்போது மிதக்கும் டைமரைத் திரையில் தெரியும்படி வைத்திருங்கள்.</string>
     <string name="settings_show_onscreen_timer_title">திரையில் டைமரைக் காட்டு</string>

--- a/feature/settings/src/main/res/values-tr-rTR/strings.xml
+++ b/feature/settings/src/main/res/values-tr-rTR/strings.xml
@@ -26,6 +26,7 @@
         <item quantity="one">%1$d dakika</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">DM\'lerde gönderilen videolar engellenmez.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">TikTok Lite uygulamasında desteklenmez</string>
     <string name="settings_allow_videos_sent_by_dms_title">DM\'lerde gönderilen videolar</string>
     <string name="settings_show_onscreen_timer_description">Kısa videolar izlerken kayan zamanlayıcıyı görünür tut.</string>
     <string name="settings_show_onscreen_timer_title">Ekran zamanlayıcısını göster</string>

--- a/feature/settings/src/main/res/values-uk-rUA/strings.xml
+++ b/feature/settings/src/main/res/values-uk-rUA/strings.xml
@@ -28,6 +28,7 @@
         <item quantity="one">%1$d хвилина</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">Не блокувати відео, надіслані в особистих повідомленнях.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">Не підтримується в TikTok Lite</string>
     <string name="settings_allow_videos_sent_by_dms_title">Відео, надіслані в особистих повідомленнях</string>
     <string name="settings_show_onscreen_timer_description">Залишати плаваючий таймер видимим під час перегляду коротких відео.</string>
     <string name="settings_show_onscreen_timer_title">Показувати таймер на екрані</string>

--- a/feature/settings/src/main/res/values-vi/strings.xml
+++ b/feature/settings/src/main/res/values-vi/strings.xml
@@ -25,6 +25,7 @@
         <item quantity="other">%1$d phút</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">Không chặn video được gửi trong tin nhắn trực tiếp.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">Không được hỗ trợ trên TikTok Lite</string>
     <string name="settings_allow_videos_sent_by_dms_title">Video được gửi trong tin nhắn trực tiếp</string>
     <string name="settings_show_onscreen_timer_description">Giữ bộ hẹn giờ nổi hiển thị khi xem video ngắn.</string>
     <string name="settings_show_onscreen_timer_title">Hiển thị bộ hẹn giờ trên màn hình</string>

--- a/feature/settings/src/main/res/values-zh-rCN/strings.xml
+++ b/feature/settings/src/main/res/values-zh-rCN/strings.xml
@@ -25,6 +25,7 @@
         <item quantity="other">%1$d 分钟</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">不拦截通过私信发送的视频。</string>
+    <string name="settings_allow_videos_sent_by_dms_note">不支持 TikTok Lite</string>
     <string name="settings_allow_videos_sent_by_dms_title">私信发送的视频</string>
     <string name="settings_show_onscreen_timer_description">观看短视频内容时，保持浮动计时器可见。</string>
     <string name="settings_show_onscreen_timer_title">显示屏幕悬浮计时器</string>

--- a/feature/settings/src/main/res/values-zh-rTW/strings.xml
+++ b/feature/settings/src/main/res/values-zh-rTW/strings.xml
@@ -25,6 +25,7 @@
         <item quantity="other">%1$d 分鐘</item>
     </plurals>
     <string name="settings_allow_videos_sent_by_dms_description">不封鎖在私訊中傳送的影片。</string>
+    <string name="settings_allow_videos_sent_by_dms_note">不支援 TikTok Lite</string>
     <string name="settings_allow_videos_sent_by_dms_title">私訊中傳送的影片</string>
     <string name="settings_show_onscreen_timer_description">觀看短影音內容時，保持浮動計時器可見。</string>
     <string name="settings_show_onscreen_timer_title">顯示螢幕浮動計時器</string>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="settings">Settings</string>
 
     <string name="settings_allow_videos_sent_by_dms_description">Do not block videos sent in DMs.</string>
+    <string name="settings_allow_videos_sent_by_dms_note">Not supported on TikTok Lite</string>
 
 
     <string name="settings_allow_videos_sent_by_dms_title">Videos sent in DMs</string>


### PR DESCRIPTION
TikTok Lite updates replaced the player ID breaking video detection. 
This fixes it, this also puts a cover instead of pressing the back position, this allows the user to navigate to dms, instead of just being blocked