### PR TITLE
feat(instagram): block reels that are shown in Instagram feed

### DIFF
--- a/app/src/main/java/com/scrolless/app/accessibility/ContentCoverDetector.kt
+++ b/app/src/main/java/com/scrolless/app/accessibility/ContentCoverDetector.kt
@@ -27,7 +27,14 @@ internal interface ContentCoverDetector {
     /** The target app this cover detector is built for. */
     val app: BlockableApp
 
+    /** App-local IDs, or fully qualified IDs for controls owned by Android. */
     val viewIds: Set<String>
+
+    /** Fully qualified scroll container ID used to clip covers before they reach native navigation. */
+    val scrollViewId: String? get() = null
+
+    /** Lets the underlying feed handle touches naturally while its video remains hidden. */
+    val passThroughTouches: Boolean get() = false
 
     /** Title shown on the overlay covering the video. */
     @get:StringRes val titleRes: Int
@@ -36,22 +43,22 @@ internal interface ContentCoverDetector {
     @get:StringRes val descriptionRes: Int
 
     /**
-     * Returns the area to cover, or `null` if the screen shouldn't be blocked.
+     * Returns the areas to cover, or an empty list if the screen shouldn't be blocked.
      *
      * @param nodes Views found on the current screen.
      * @param activeCoverBounds The current cover's bounds, so an already covered player stays covered.
      */
-    fun coverBounds(nodes: List<ContentCoverNode>, activeCoverBounds: ContentBounds? = null): ContentBounds?
+    fun coverBounds(nodes: List<ContentCoverNode>, activeCoverBounds: List<ContentBounds> = emptyList()): List<ContentBounds>
 }
 
 /** A lightweight view representation (ID, bounds, and visibility) passed to cover detectors. */
-internal data class ContentCoverNode(val viewId: String, val bounds: ContentBounds, val isVisible: Boolean)
+internal data class ContentCoverNode(val viewId: String, val bounds: ContentBounds, val isVisible: Boolean, val isSelected: Boolean = false)
 
 /** All active cover detectors registered in the app. */
 private val coverDetectors: Map<BlockableApp, ContentCoverDetector> = listOf(
     TikTokScreenDetector(BlockableApp.TIKTOK),
     TikTokScreenDetector(BlockableApp.TIKTOK_LITE),
-    // Add future app cover detectors here (e.g. InstagramScreenDetector)
+    InstagramFeedScreenDetector,
 ).associateBy { it.app }
 
 /** Returns cover rules for this app, or null if it uses full-screen blocking (Back or Home). */

--- a/app/src/main/java/com/scrolless/app/accessibility/ContentScanner.kt
+++ b/app/src/main/java/com/scrolless/app/accessibility/ContentScanner.kt
@@ -174,21 +174,37 @@ internal class ContentScanner(
         activeCover: ContentCover? = null,
     ): ContentCover? {
         val detector = app.coverDetector ?: return null
+        val attachToWindow = useWindowAttachedCover
         val activeBounds = activeCover?.target?.takeIf { target ->
             when (target) {
                 is ContentCoverTarget.Window -> target.windowId == windowId
-                is ContentCoverTarget.Screen -> !useWindowAttachedCover
+                is ContentCoverTarget.Screen -> !attachToWindow
             }
+        }?.let { target ->
+            when (target) {
+                is ContentCoverTarget.Screen -> target.regions
+                is ContentCoverTarget.Window -> target.regions.ifEmpty { listOf(target.bounds) }
+            }
+        }.orEmpty()
+        val nodes = coverNodes(app, detector.viewIds, attachToWindow)
+        val observedAt = android.os.SystemClock.uptimeMillis()
+        val regions = detector.coverBounds(nodes, activeBounds)
+        if (regions.isEmpty()) return null
+        val viewport = nodes.firstOrNull {
+            it.viewId == detector.scrollViewId && it.isVisible && it.bounds.isVisible
         }?.bounds
-        val bounds = detector.coverBounds(coverNodes(app, detector.viewIds), activeBounds) ?: return null
         // Older Android positions covers on the screen. Android 14+ attaches them to an app window.
-        val target = if (useWindowAttachedCover) {
+        val target = if (attachToWindow) {
             val targetWindow = appWindows.roots.keys.firstOrNull { it.id == windowId } ?: return null
-            ContentCoverTarget.Window(windowId, targetWindow.displayId, bounds)
+            if (detector.passThroughTouches) {
+                ContentCoverTarget.Window(windowId, targetWindow.displayId, viewport ?: coverBounds(true), regions)
+            } else {
+                ContentCoverTarget.Window(windowId, targetWindow.displayId, regions.single())
+            }
         } else {
-            ContentCoverTarget.Screen(bounds)
+            ContentCoverTarget.Screen(regions, viewport)
         }
-        return ContentCover(target, detector.titleRes, detector.descriptionRes)
+        return ContentCover(target, detector.titleRes, detector.descriptionRes, detector.passThroughTouches, observedAt)
     }
 
     /** Looks for blocked content across all visible windows of [blockableApp]. */
@@ -236,17 +252,21 @@ internal class ContentScanner(
     }
 
     // Read only the IDs requested by this app's detector; do not walk the whole screen tree.
-    private fun AccessibilityNodeInfo.coverNodes(app: ResolvedBlockableApp, viewIds: Set<String>): List<ContentCoverNode> =
-        viewIds.flatMap { id ->
-            findAccessibilityNodeInfosByViewId("${app.packageId}:id/$id").map { node ->
-                ContentCoverNode(id, node.coverBounds(), node.isVisibleToUser)
-            }
+    private fun AccessibilityNodeInfo.coverNodes(
+        app: ResolvedBlockableApp,
+        viewIds: Set<String>,
+        inWindow: Boolean,
+    ): List<ContentCoverNode> = viewIds.flatMap { id ->
+        val qualifiedId = if (':' in id) id else "${app.packageId}:id/$id"
+        findAccessibilityNodeInfosByViewId(qualifiedId).map { node ->
+            ContentCoverNode(id, node.coverBounds(inWindow), node.isVisibleToUser, node.isSelected)
         }
+    }
 
     // The rectangle must use the same origin as the overlay that will draw it.
-    private fun AccessibilityNodeInfo.coverBounds(): ContentBounds {
+    private fun AccessibilityNodeInfo.coverBounds(inWindow: Boolean = useWindowAttachedCover): ContentBounds {
         val bounds = android.graphics.Rect()
-        if (useWindowAttachedCover) {
+        if (inWindow && Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             getBoundsInWindow(bounds)
         } else {
             getBoundsInScreen(bounds)
@@ -296,7 +316,11 @@ internal class ContentScanner(
         if (rule.requiredViewIds.any { !hasVisibleViewId(app.getViewId(it)) }) return false
 
         rule.replyLabelsBelowPlayer?.let { labels ->
-            if (cover == null || !hasReplyBelowPlayer(labels, cover.target.bounds) { it.coverBounds() }) return false
+            if (cover == null ||
+                !hasReplyBelowPlayer(labels, cover.target.bounds) {
+                    it.coverBounds(cover.target is ContentCoverTarget.Window)
+                }
+            ) return false
         }
 
         // If any-of elements are specified, at least one must be present on screen.

--- a/app/src/main/java/com/scrolless/app/accessibility/FeedContentScanQueue.kt
+++ b/app/src/main/java/com/scrolless/app/accessibility/FeedContentScanQueue.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2026 Scrolless
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.scrolless.app.accessibility
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/** Keeps feed scans off the UI thread without accumulating a backlog of scroll events. */
+internal class FeedContentScanQueue(
+    private val scope: CoroutineScope,
+    private val onResult: (ContentScanner.Result) -> Unit,
+    private val worker: CoroutineDispatcher = Dispatchers.Default,
+) {
+    private var pending: (() -> ContentScanner.Result)? = null
+    private var running = false
+    private var revision = 0L
+
+    /** Called on the main thread with a scan whose inputs have already been captured. */
+    fun submit(scan: () -> ContentScanner.Result) {
+        pending = scan
+        if (running) return
+        running = true
+        scope.launch {
+            try {
+                while (true) {
+                    val next = pending ?: break
+                    pending = null
+                    val startedRevision = revision
+                    val result = withContext(worker) { next() }
+                    if (startedRevision == revision) onResult(result)
+                }
+            } finally {
+                running = false
+            }
+        }
+    }
+
+    /** Navigation or preference changes make both queued and in-flight results obsolete. */
+    fun invalidate() {
+        revision++
+        pending = null
+    }
+}

--- a/app/src/main/java/com/scrolless/app/accessibility/InstagramFeedScreenDetector.kt
+++ b/app/src/main/java/com/scrolless/app/accessibility/InstagramFeedScreenDetector.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 Scrolless
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.scrolless.app.accessibility
+
+import com.scrolless.app.R
+import com.scrolless.app.core.model.BlockableApp
+
+/** Covers inline videos on Instagram Home without treating photo posts as Reels. */
+internal object InstagramFeedScreenDetector : ContentCoverDetector {
+    override val app = BlockableApp.REELS
+    override val scrollViewId = "android:id/list"
+    override val viewIds = setOf("feed_tab", scrollViewId, "clips_viewer_view_pager", "video_container")
+    override val passThroughTouches = true
+    override val titleRes = R.string.instagram_feed_blocked_title
+    override val descriptionRes = R.string.instagram_feed_blocked_description
+
+    /**
+     * Requires the selected Home tab and the standalone video container. Photo carousels with
+     * music use separate carousel video containers; playback-state views alone are not enough.
+     * The tab stays available when scrolling hides or removes the Home header.
+     * Leaves the full-screen viewer to its existing blocking and DM rules. An occluded video
+     * stays covered only while its bounds still match a current cover. Cover every visible
+     * video separately so the content between posts remains accessible.
+     */
+    override fun coverBounds(nodes: List<ContentCoverNode>, activeCoverBounds: List<ContentBounds>): List<ContentBounds> {
+        if (nodes.none { it.viewId == "feed_tab" && it.isSelected && it.isVisible && it.bounds.isVisible }) return emptyList()
+        if (nodes.any { it.viewId == "clips_viewer_view_pager" && it.isVisible && it.bounds.isVisible }) return emptyList()
+        return nodes.filter {
+            it.viewId == "video_container" && it.bounds.isVisible && (it.isVisible || it.bounds in activeCoverBounds)
+        }.map { it.bounds }.distinct()
+    }
+}

--- a/app/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
+++ b/app/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
@@ -19,6 +19,7 @@ package com.scrolless.app.accessibility
 import android.accessibilityservice.AccessibilityService
 import android.accessibilityservice.AccessibilityServiceInfo
 import android.annotation.SuppressLint
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.os.PowerManager
@@ -35,6 +36,7 @@ import com.scrolless.app.core.repository.SessionTracker
 import com.scrolless.app.core.repository.UserSettingsStore
 import com.scrolless.app.debug.DebugOverlayConfig
 import com.scrolless.app.ui.overlay.BlockedContentOverlayManager
+import com.scrolless.app.ui.overlay.FeedScrollMotion
 import com.scrolless.app.ui.overlay.TimerOverlayManager
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -89,6 +91,7 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
         if (BuildConfig.DEBUG) {
             serviceScope.launch {
                 DebugOverlayConfig.forceLegacyOverlay.drop(1).collect {
+                    invalidateFeedScans()
                     if (contentSession?.content?.cover != null) {
                         onBlockedContentExited()
                     }
@@ -136,6 +139,30 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
     /** Scans the window tree to find target apps, videos, and compute cover coordinates. */
     private val contentScanner by lazy {
         ContentScanner(this, { isWindowAttachedCoverAllowed }, { currentAllowVideosSentByDm })
+    }
+
+    private val feedContentScans by lazy { FeedContentScanQueue(serviceScope, ::applyContentScan) }
+    private var lastFeedScrollTime = 0L
+    private val feedScrollSettled = Runnable {
+        blockedContentOverlayManager.stopFeedScroll()
+        currentForegroundBrainRotApp?.takeIf { it.coverDetector?.passThroughTouches == true }?.let(::requestFeedScan)
+    }
+
+    private fun invalidateFeedScans() {
+        feedContentScans.invalidate()
+        mainHandler.removeCallbacks(feedScrollSettled)
+        lastFeedScrollTime = 0
+        blockedContentOverlayManager.stopFeedScroll()
+    }
+
+    private fun requestFeedScan(foregroundApp: ResolvedBlockableApp) {
+        // Capture settings and session state on main; only window/node lookups run on the worker.
+        val windowAttached = isWindowAttachedCoverAllowed
+        val allowDm = currentAllowVideosSentByDm
+        val scanner = ContentScanner(this, { windowAttached }, { allowDm })
+        val trackedApp = contentSession?.app
+        val activeCover = contentSession?.takeIf { it.isCovered }?.content?.cover
+        feedContentScans.submit { scanner.scan(foregroundApp.packageId, false, trackedApp, foregroundApp, activeCover) }
     }
 
     /**
@@ -261,6 +288,7 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
         // Re-detect an open video when the DM preference changes, then apply the new decision.
         serviceScope.launch {
             userSettingsStore.getAllowVideosSentByDm().collect {
+                invalidateFeedScans()
                 currentAllowVideosSentByDm = it
                 refreshDetectedContent()
                 reconsiderVisibleContent()
@@ -282,6 +310,7 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
      * @param reason Diagnostic message for logs explaining why the session ended.
      */
     private fun handleTrackedAppExit(reason: String) {
+        invalidateFeedScans()
         // A window cover can outlive tracking while its parent animates away. Screen-off clears it.
         if (!powerManager.isInteractive) blockedContentOverlayManager.hide()
         if (contentSession == null && currentForegroundBrainRotApp == null) {
@@ -340,13 +369,43 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
             return
         }
 
+        val packageId = event.packageName?.toString()
+        val foregroundApp = currentForegroundBrainRotApp
+        if (foregroundApp?.coverDetector?.passThroughTouches == true && packageId == foregroundApp.packageId &&
+            (event.eventType == AccessibilityEvent.TYPE_VIEW_SCROLLED || event.eventType == AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED)
+        ) {
+            if (event.eventType == AccessibilityEvent.TYPE_VIEW_SCROLLED && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                val sourceId = event.source?.viewIdResourceName
+                // Carousels and comment lists must not move covers over the Home feed.
+                if (sourceId != null && sourceId == foregroundApp.coverDetector?.scrollViewId) {
+                    blockedContentOverlayManager.onFeedScroll(event.scrollDeltaY, event.eventTime)
+                    lastFeedScrollTime = event.eventTime
+                    mainHandler.removeCallbacks(feedScrollSettled)
+                    mainHandler.postDelayed(feedScrollSettled, FeedScrollMotion.IDLE_MILLIS)
+                }
+            } else if (lastFeedScrollTime > 0 && event.eventTime - lastFeedScrollTime in 0..100) {
+                // Scrolling also emits content-change events. The scroll scan already reconciles this batch.
+                return
+            }
+            requestFeedScan(foregroundApp)
+            return
+        }
+
+        // Process navigation immediately and reject any scan started before this event.
+        invalidateFeedScans()
+
         val scan = contentScanner.scan(
-            event.packageName?.toString(),
+            packageId,
             event.eventType == AccessibilityEvent.TYPE_WINDOWS_CHANGED,
             contentSession?.app,
             currentForegroundBrainRotApp,
             contentSession?.takeIf { it.isCovered }?.content?.cover,
         )
+        applyContentScan(scan)
+    }
+
+    /** Applies a completed scan on main, where sessions, navigation and overlays are owned. */
+    private fun applyContentScan(scan: ContentScanner.Result) {
         if (scan.trackedAppExited) handleTrackedAppExit("covered app lost foreground")
         val userActiveApp = scan.foregroundApp
         updateForegroundAppState(userActiveApp)
@@ -377,6 +436,8 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
         val previousApp = currentForegroundBrainRotApp
         if (previousApp == nextApp) return
 
+        invalidateFeedScans()
+
         if (previousApp != null) {
             Timber.v("*** User appears to have left a brain rot app: %s (%s)", previousApp.app.name, previousApp.packageId)
             sessionTracker.onAppClose()
@@ -403,6 +464,7 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
         )
         stopPeriodicCheck()
         mainHandler.removeCallbacks(coveredContentCheck)
+        invalidateFeedScans()
         blockedContentOverlayManager.hide()
         timerOverlayManager.cleanup()
         serviceScope.cancel()
@@ -519,6 +581,7 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
      * @param appLeft True if the user switched away from the host app entirely.
      */
     private fun onBlockedContentExited(appLeft: Boolean = false) {
+        invalidateFeedScans()
         val session = contentSession
         contentSession = null
         val hadCover = session?.content?.cover != null
@@ -584,6 +647,8 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
                 }
                 // Stop counting only after the cover was shown successfully.
                 val finished = session.cover(System.currentTimeMillis()) ?: return
+                // Earlier scans did not know this player was covered and may report it as absent.
+                invalidateFeedScans()
                 stopPeriodicCheck()
                 timerOverlayManager.dismissImmediately()
                 refreshServiceConfig()
@@ -655,7 +720,14 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
         val info = serviceInfo ?: return
 
         // Do not delay Home/app-switching events while covered, or the old screen cover can linger.
-        info.notificationTimeout = if (contentSession?.isCovered == true) 0L else DEFAULT_NOTIFICATION_TIMEOUT_MS
+        val followsFeedScroll = currentForegroundBrainRotApp?.coverDetector?.passThroughTouches == true
+        info.notificationTimeout = if (contentSession?.isCovered == true || followsFeedScroll) 0L else DEFAULT_NOTIFICATION_TIMEOUT_MS
+        // Feed videos move during scrolling even when their content does not change.
+        info.eventTypes = if (followsFeedScroll) {
+            info.eventTypes or AccessibilityEvent.TYPE_VIEW_SCROLLED
+        } else {
+            info.eventTypes and AccessibilityEvent.TYPE_VIEW_SCROLLED.inv()
+        }
 
         if (listenToAll) {
             info.packageNames = null // Listen to all

--- a/app/src/main/java/com/scrolless/app/accessibility/TikTokScreenDetector.kt
+++ b/app/src/main/java/com/scrolless/app/accessibility/TikTokScreenDetector.kt
@@ -36,7 +36,9 @@ internal class TikTokScreenDetector(override val app: BlockableApp) : ContentCov
      * to the user because our opaque cover occludes it. In that case, keep it covered as long
      * as the player view remains at the covered bounds.
      */
-    override fun coverBounds(nodes: List<ContentCoverNode>, activeCoverBounds: ContentBounds?): ContentBounds? = nodes.firstOrNull {
-        it.viewId == playerViewId && it.bounds.isVisible && (it.isVisible || it.bounds == activeCoverBounds)
-    }?.bounds
+    override fun coverBounds(nodes: List<ContentCoverNode>, activeCoverBounds: List<ContentBounds>): List<ContentBounds> = listOfNotNull(
+        nodes.firstOrNull {
+            it.viewId == playerViewId && it.bounds.isVisible && (it.isVisible || it.bounds in activeCoverBounds)
+        }?.bounds,
+    )
 }

--- a/app/src/main/java/com/scrolless/app/ui/overlay/BlockedContentOverlayManager.kt
+++ b/app/src/main/java/com/scrolless/app/ui/overlay/BlockedContentOverlayManager.kt
@@ -43,6 +43,7 @@ class BlockedContentOverlayManager @Inject constructor() {
     private var view: View? = null
     private var shownCover: ContentCover? = null
     private var windowOverlay: WindowAttachedContentOverlay? = null
+    private var feedWindowOverlay: WindowAttachedFeedOverlay? = null
 
     fun attachServiceContext(service: AccessibilityService) {
         this.service = service
@@ -59,12 +60,21 @@ class BlockedContentOverlayManager @Inject constructor() {
         // Different text or a different rendering mode needs a fresh view, not a resize.
         shownCover?.let { if (!cover.canReuseView(it)) hide() }
         // Accessibility sends many identical events. Leave an unchanged cover alone.
-        if (!target.needsUpdate(shownCover?.target, refreshAttachment)) return true
+        if (!target.needsUpdate(shownCover?.target, refreshAttachment) && !cover.passThroughTouches) return true
         when (target) {
             is ContentCoverTarget.Screen -> showScreenCover(cover)
 
             is ContentCoverTarget.Window -> {
                 if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) return false
+                if (cover.passThroughTouches) {
+                    val overlay = feedWindowOverlay ?: WindowAttachedFeedOverlay(service).also { feedWindowOverlay = it }
+                    if (!overlay.show(cover, refreshAttachment)) {
+                        hide()
+                        return false
+                    }
+                    shownCover = cover
+                    return true
+                }
                 val overlay = windowOverlay ?: WindowAttachedContentOverlay(service) { createCoverView(it, cover) }.also {
                     windowOverlay = it
                 }
@@ -83,24 +93,40 @@ class BlockedContentOverlayManager @Inject constructor() {
         if (shownCover?.target?.keepOnAppExit(screenInteractive) != true) hide()
     }
 
+    internal fun onFeedScroll(deltaY: Int, eventTime: Long) {
+        (view as? FeedContentCoverView)?.onScroll(deltaY, eventTime)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) feedWindowOverlay?.onScroll(deltaY, eventTime)
+    }
+
+    internal fun stopFeedScroll() {
+        (view as? FeedContentCoverView)?.stopScroll()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) feedWindowOverlay?.stopScroll()
+    }
+
     /** Draws the legacy cover using screen coordinates on Android versions without window attachment. */
     @SuppressLint("RtlHardcoded")
     private fun showScreenCover(cover: ContentCover) {
+        val currentView = view
+        if (currentView is FeedContentCoverView) {
+            currentView.update(cover)
+            return
+        }
         val bounds = cover.target.bounds
 
         // Keep app focus and accept touches only inside this rectangle. Native tabs stay usable.
         val params = WindowManager.LayoutParams(
-            bounds.width,
-            bounds.height,
+            if (cover.passThroughTouches) WindowManager.LayoutParams.MATCH_PARENT else bounds.width,
+            if (cover.passThroughTouches) WindowManager.LayoutParams.MATCH_PARENT else bounds.height,
             WindowManager.LayoutParams.TYPE_ACCESSIBILITY_OVERLAY,
             WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
-                WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN,
-            PixelFormat.OPAQUE,
+                WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
+                (if (cover.passThroughTouches) WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE else 0),
+            if (cover.passThroughTouches) PixelFormat.TRANSLUCENT else PixelFormat.OPAQUE,
         ).apply {
             // Accessibility gives physical left/top coordinates, even in right-to-left languages.
             gravity = Gravity.TOP or Gravity.LEFT
-            x = bounds.left
-            y = bounds.top
+            x = if (cover.passThroughTouches) 0 else bounds.left
+            y = if (cover.passThroughTouches) 0 else bounds.top
             // Do not let system-bar or cutout padding shift the rectangle Android reported.
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                 setFitInsetsTypes(0)
@@ -110,9 +136,10 @@ class BlockedContentOverlayManager @Inject constructor() {
             }
         }
 
-        val currentView = view
         if (currentView == null) {
-            val newView = createCoverView(service, cover)
+            val newView = if (cover.passThroughTouches) FeedContentCoverView(service).apply {
+                update(cover)
+            } else createCoverView(service, cover)
             windowManager.addView(newView, params)
             view = newView
         } else {
@@ -127,8 +154,10 @@ class BlockedContentOverlayManager @Inject constructor() {
         view = null
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             windowOverlay?.hide()
+            feedWindowOverlay?.hide()
         }
         windowOverlay = null
+        feedWindowOverlay = null
         shownCover = null
     }
 
@@ -140,7 +169,7 @@ class BlockedContentOverlayManager @Inject constructor() {
         setPadding(padding, padding, padding, padding)
         // The timer color may be translucent. The blocker must be fully opaque to hide the video.
         setBackgroundColor(timerOverlayBackgroundColor.toArgb() or 0xFF000000.toInt())
-        // Consume taps and swipes rather than allowing them to reach the video beneath us.
+        // Consume touches inside the covered player.
         isClickable = true
         addView(
             TextView(context).apply {

--- a/app/src/main/java/com/scrolless/app/ui/overlay/ContentCoverTarget.kt
+++ b/app/src/main/java/com/scrolless/app/ui/overlay/ContentCoverTarget.kt
@@ -24,12 +24,16 @@ internal data class ContentCover(
     val target: ContentCoverTarget,
     @param:StringRes val titleRes: Int,
     @param:StringRes val descriptionRes: Int,
+    val passThroughTouches: Boolean = false,
+    /** Uptime when these rectangles were read; prediction never changes the measured geometry. */
+    val observedAtMillis: Long = 0,
 ) {
     /**
      * Whether an existing cover view can display this cover.
-     * Moving or resizing can reuse the view, but different text or a different overlay type cannot.
+     * Moving or resizing can reuse the view, but different text, touch behavior or a different overlay type cannot.
      */
     fun canReuseView(previous: ContentCover): Boolean = titleRes == previous.titleRes && descriptionRes == previous.descriptionRes &&
+        passThroughTouches == previous.passThroughTouches &&
         (target is ContentCoverTarget.Window) == (previous.target is ContentCoverTarget.Window)
 }
 
@@ -43,13 +47,28 @@ internal sealed interface ContentCoverTarget {
      * Positions the cover from the phone screen's top-left corner.
      * Used by the legacy overlay, which must be removed when the user leaves the app.
      */
-    data class Screen(override val bounds: ContentBounds) : ContentCoverTarget
+    data class Screen(val regions: List<ContentBounds>, val viewport: ContentBounds? = null) : ContentCoverTarget {
+        constructor(bounds: ContentBounds) : this(listOf(bounds))
+
+        init {
+            require(regions.isNotEmpty())
+        }
+
+        // Single-player overlays and DM checks use the first region.
+        override val bounds: ContentBounds get() = regions.first()
+    }
 
     /**
      * Positions the cover from an app window's top-left corner on Android 14+.
      * Attaching it to that window lets Android move them together during app switching.
      */
-    data class Window(val windowId: Int, val displayId: Int, override val bounds: ContentBounds) : ContentCoverTarget
+    data class Window(
+        val windowId: Int,
+        val displayId: Int,
+        override val bounds: ContentBounds,
+        /** Separate video rectangles inside a feed viewport; empty for a single-player cover. */
+        val regions: List<ContentBounds> = emptyList(),
+    ) : ContentCoverTarget
 }
 
 /** Keep attached covers during Home/Recents gestures. Remove screen covers so they do not cover the launcher. */

--- a/app/src/main/java/com/scrolless/app/ui/overlay/FeedContentCoverView.kt
+++ b/app/src/main/java/com/scrolless/app/ui/overlay/FeedContentCoverView.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2026 Scrolless
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.scrolless.app.ui.overlay
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Typeface
+import android.text.Layout
+import android.text.StaticLayout
+import android.text.TextPaint
+import android.view.View
+import androidx.compose.ui.graphics.toArgb
+import com.scrolless.app.accessibility.ContentBounds
+import com.scrolless.app.designsystem.theme.timerOverlayBackgroundColor
+import androidx.core.graphics.withClip
+
+/**
+ * Draws feed covers inside a stationary, touch-through window. Moving the rectangle only schedules
+ * a redraw, avoiding WindowManager moves and resizes on every accessibility update during a fling.
+ */
+// TODO Warning:(36, 16) Custom view `FeedContentCoverView` is missing constructor used by tools: `(Context)` or `(Context,AttributeSet)` or `(Context,AttributeSet,int)`
+internal class FeedContentCoverView(context: Context, private val requestFrame: (() -> Unit)? = null) : View(context) {
+    private var cover: ContentCover? = null
+    private val motion = FeedScrollMotion()
+    private val textLayouts = mutableMapOf<Int, Pair<StaticLayout, StaticLayout>>()
+    private val padding = 32 * resources.displayMetrics.density
+    private val background = timerOverlayBackgroundColor.toArgb() or 0xFF000000.toInt()
+
+    init {
+        importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO
+    }
+
+    /** Reuses text layouts while the video width is unchanged and batches drawing at the next frame. */
+    fun update(next: ContentCover) {
+        val regions = regions(next.target)
+        if (next.titleRes != cover?.titleRes || next.descriptionRes != cover?.descriptionRes) textLayouts.clear()
+        val widths = regions.map(::textWidth).toSet()
+        textLayouts.keys.retainAll(widths)
+        widths.forEach { width ->
+            textLayouts.getOrPut(width) {
+                textLayout(context.getString(next.titleRes), width, 24f, true) to
+                    textLayout(context.getString(next.descriptionRes), width, 16f, false)
+            }
+        }
+        cover = next
+        redraw()
+    }
+
+    fun onScroll(deltaY: Int, eventTime: Long) {
+        motion.onScroll(deltaY, eventTime)
+        redraw()
+    }
+
+    fun stopScroll() {
+        motion.reset()
+        redraw()
+    }
+
+    private fun redraw() {
+        if (requestFrame != null) requestFrame.invoke() else postInvalidateOnAnimation()
+    }
+
+    /** Keeps everything outside the reported video rectangle transparent, including native navigation. */
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        val current = cover ?: return
+        val target = current.target
+        val viewport = viewport(target)
+        val now = android.os.SystemClock.uptimeMillis()
+        val offset = motion.offset(current.observedAtMillis, now)
+        val regions = regions(target)
+        for (region in regions) {
+            val bounds = viewport?.let { motion.project(region, it, offset) } ?: region
+            if (!bounds.isVisible) continue
+            canvas.withClip(bounds.left, bounds.top, bounds.right, bounds.bottom) {
+                drawColor(background)
+                val (heading, detail) = textLayouts.getValue(textWidth(region))
+                val messageHeight = heading.height + padding / 2 + detail.height
+                // Center within this Reel's visible cover, using the same geometry as its mask.
+                // Small remaining slivers stay covered without showing fragments of the message.
+                if (bounds.height >= messageHeight + 2 * padding) {
+                    translate(bounds.left + padding, bounds.top + (bounds.height - messageHeight) / 2)
+                    heading.draw(this)
+                    translate(0f, heading.height + padding / 2)
+                    detail.draw(this)
+                }
+            }
+        }
+        if (viewport != null && motion.isMoving(now)) redraw()
+    }
+
+    private fun regions(target: ContentCoverTarget): List<ContentBounds> = when (target) {
+        is ContentCoverTarget.Screen -> target.regions
+        is ContentCoverTarget.Window -> target.regions
+    }
+
+    private fun viewport(target: ContentCoverTarget): ContentBounds? = when (target) {
+        is ContentCoverTarget.Screen -> target.viewport
+        is ContentCoverTarget.Window -> target.bounds
+    }
+
+    private fun textWidth(bounds: ContentBounds): Int = (bounds.width - 2 * padding).toInt().coerceAtLeast(1)
+
+    /** Wraps the message once per width change and respects the user's font scaling. */
+    private fun textLayout(text: String, width: Int, size: Float, bold: Boolean): StaticLayout {
+        val paint = TextPaint(TextPaint.ANTI_ALIAS_FLAG).apply {
+            color = Color.WHITE
+            textSize = android.util.TypedValue.applyDimension(android.util.TypedValue.COMPLEX_UNIT_SP, size, resources.displayMetrics)
+            typeface = if (bold) Typeface.DEFAULT_BOLD else Typeface.DEFAULT
+        }
+        return StaticLayout.Builder.obtain(text, 0, text.length, paint, width)
+            .setAlignment(Layout.Alignment.ALIGN_CENTER)
+            .setIncludePad(false)
+            .build()
+    }
+}

--- a/app/src/main/java/com/scrolless/app/ui/overlay/FeedScrollMotion.kt
+++ b/app/src/main/java/com/scrolless/app/ui/overlay/FeedScrollMotion.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 Scrolless
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.scrolless.app.ui.overlay
+
+import com.scrolless.app.accessibility.ContentBounds
+import kotlin.math.roundToInt
+
+/** Short, bounded prediction between the feed's batched accessibility scroll events. */
+internal class FeedScrollMotion {
+    private var eventTime = 0L
+    private var pixelsPerMillis = 0f
+
+    fun onScroll(deltaY: Int, timeMillis: Long) {
+        if (timeMillis <= eventTime) return
+        val elapsed = if (eventTime > 0 && timeMillis - eventTime < IDLE_MILLIS) timeMillis - eventTime else 100L
+        pixelsPerMillis = -deltaY.toFloat() / elapsed
+        eventTime = timeMillis
+    }
+
+    fun reset() {
+        eventTime = 0
+        pixelsPerMillis = 0f
+    }
+
+    fun isMoving(nowMillis: Long): Boolean = eventTime > 0 && nowMillis - eventTime in 0 until IDLE_MILLIS && pixelsPerMillis != 0f
+
+    fun offset(observedAtMillis: Long, nowMillis: Long): Int {
+        if (observedAtMillis <= 0 || !isMoving(nowMillis)) return 0
+        return (pixelsPerMillis * (nowMillis - observedAtMillis).coerceIn(0, 80)).roundToInt()
+    }
+
+    /** A clipped edge may hide more video outside the viewport; keep it covered as it enters. */
+    fun project(bounds: ContentBounds, viewport: ContentBounds, offset: Int): ContentBounds = bounds.copy(
+        top = if (bounds.top <= viewport.top && offset > 0) viewport.top else maxOf(viewport.top, bounds.top + offset),
+        bottom = if (bounds.bottom >= viewport.bottom && offset < 0) viewport.bottom else minOf(viewport.bottom, bounds.bottom + offset),
+    )
+
+    companion object {
+        // Android batches recurring scroll events at about 100 ms. Do not coast beyond a missing batch.
+        const val IDLE_MILLIS = 160L
+    }
+}

--- a/app/src/main/java/com/scrolless/app/ui/overlay/WindowAttachedFeedOverlay.kt
+++ b/app/src/main/java/com/scrolless/app/ui/overlay/WindowAttachedFeedOverlay.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2026 Scrolless
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.scrolless.app.ui.overlay
+
+import android.accessibilityservice.AccessibilityService
+import android.graphics.Color
+import android.graphics.PixelFormat
+import android.graphics.PorterDuff
+import android.hardware.display.DisplayManager
+import android.os.Build
+import android.view.Choreographer
+import android.view.Surface
+import android.view.SurfaceControl
+import androidx.annotation.RequiresApi
+import timber.log.Timber
+
+/** A drawable app-window child with no input window, so Instagram keeps native touch handling. */
+@RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+internal class WindowAttachedFeedOverlay(private val service: AccessibilityService) {
+    private var control: SurfaceControl? = null
+    private var surface: Surface? = null
+    private var painter: FeedContentCoverView? = null
+    private var target: ContentCoverTarget.Window? = null
+    private val choreographer = Choreographer.getInstance()
+    private var framePending = false
+    private val frame = Choreographer.FrameCallback {
+        framePending = false
+        try {
+            draw()
+        } catch (error: RuntimeException) {
+            Timber.e(error, "Unable to draw attached feed cover")
+            hide()
+        }
+    }
+
+    fun show(cover: ContentCover, refreshAttachment: Boolean): Boolean {
+        val next = cover.target as ContentCoverTarget.Window
+        if (target?.windowId != next.windowId || target?.displayId != next.displayId) hide()
+        val previous = target
+        try {
+            val width = next.bounds.right.coerceAtLeast(1)
+            val height = next.bounds.bottom.coerceAtLeast(1)
+            val sc = control ?: SurfaceControl.Builder()
+                .setName("ScrollessFeedCover")
+                .setBufferSize(width, height)
+                .setFormat(PixelFormat.RGBA_8888)
+                .build().also {
+                    control = it
+                    surface = Surface(it)
+                    val display = service.getSystemService(DisplayManager::class.java).getDisplay(next.displayId)
+                    requireNotNull(display)
+                    painter = FeedContentCoverView(service.createDisplayContext(display), ::scheduleFrame)
+                }
+            if (previous?.bounds?.right != width || previous.bounds.bottom != height) {
+                SurfaceControl.Transaction().use {
+                    it.setBufferSize(sc, width, height).setLayer(sc, Int.MAX_VALUE).setVisibility(sc, true).apply()
+                }
+            }
+            val view = requireNotNull(painter)
+            view.layout(0, 0, width, height)
+            view.update(cover)
+            if (previous == null) draw()
+            if (refreshAttachment || previous?.windowId != next.windowId || previous.displayId != next.displayId) {
+                service.attachAccessibilityOverlayToWindow(next.windowId, sc)
+            }
+            target = next
+            return true
+        } catch (error: RuntimeException) {
+            Timber.e(error, "Unable to attach feed cover")
+            hide()
+            return false
+        }
+    }
+
+    fun onScroll(deltaY: Int, eventTime: Long) {
+        painter?.onScroll(deltaY, eventTime)
+    }
+
+    fun stopScroll() {
+        painter?.stopScroll()
+    }
+
+    private fun scheduleFrame() {
+        if (framePending) return
+        framePending = true
+        choreographer.postFrameCallback(frame)
+    }
+
+    private fun draw() {
+        val output = surface ?: return
+        val view = painter ?: return
+        val canvas = output.lockHardwareCanvas()
+        try {
+            canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR)
+            view.draw(canvas)
+        } finally {
+            output.unlockCanvasAndPost(canvas)
+        }
+    }
+
+    fun hide() {
+        choreographer.removeFrameCallback(frame)
+        framePending = false
+        painter = null
+        target = null
+        surface?.release()
+        surface = null
+        control?.let { sc ->
+            SurfaceControl.Transaction().use { it.setVisibility(sc, false).reparent(sc, null).apply() }
+            sc.release()
+        }
+        control = null
+    }
+}

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">TikTok video-snimci su blokirani</string>
     <string name="tiktok_blocked_description">Koristite kartice na dnu da biste otvorili „Prijemno sanduče” ili „Profil”.</string>
+    <string name="instagram_feed_blocked_title">Instagram video-snimci su blokirani</string>
+    <string name="instagram_feed_blocked_description">Koristite kartice na dnu da biste otvorili „Prijemno sanduče” ili „Profil”.</string>
 </resources>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">Els vídeos de TikTok estan bloquejats</string>
     <string name="tiktok_blocked_description">Fes servir les pestanyes de sota per obrir la Safata d\'entrada o el Perfil.</string>
+    <string name="instagram_feed_blocked_title">Els vídeos d\'Instagram estan bloquejats</string>
+    <string name="instagram_feed_blocked_description">Fes servir les pestanyes de sota per obrir la Safata d\'entrada o el Perfil.</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">Videa na TikToku jsou zablokována</string>
     <string name="tiktok_blocked_description">Pomocí karet dole otevřete „Doručenou poštu“ nebo „Profil“.</string>
+    <string name="instagram_feed_blocked_title">Videa na Instagramu jsou zablokována</string>
+    <string name="instagram_feed_blocked_description">Pomocí karet dole otevřete „Doručenou poštu“ nebo „Profil“.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">TikTok-Videos sind blockiert</string>
     <string name="tiktok_blocked_description">Verwenden Sie die Tabs unten, um den Posteingang oder das Profil zu öffnen.</string>
+    <string name="instagram_feed_blocked_title">Instagram-Videos sind blockiert</string>
+    <string name="instagram_feed_blocked_description">Verwenden Sie die Tabs unten, um den Posteingang oder das Profil zu öffnen.</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">Τα βίντεο του TikTok είναι αποκλεισμένα</string>
     <string name="tiktok_blocked_description">Χρησιμοποιήστε τις καρτέλες παρακάτω για να ανοίξετε τα Εισερχόμενα ή το Προφίλ.</string>
+    <string name="instagram_feed_blocked_title">Τα βίντεο του Instagram είναι αποκλεισμένα</string>
+    <string name="instagram_feed_blocked_description">Χρησιμοποιήστε τις καρτέλες παρακάτω για να ανοίξετε τα Εισερχόμενα ή το Προφίλ.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">Los vídeos de TikTok están bloqueados</string>
     <string name="tiktok_blocked_description">Usa las pestañas de abajo para abrir la Bandeja de entrada o el Perfil.</string>
+    <string name="instagram_feed_blocked_title">Los vídeos de Instagram están bloqueados</string>
+    <string name="instagram_feed_blocked_description">Usa las pestañas de abajo para abrir la Bandeja de entrada o el Perfil.</string>
 </resources>

--- a/app/src/main/res/values-fi-rFI/strings.xml
+++ b/app/src/main/res/values-fi-rFI/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">TikTok-videot on estetty</string>
     <string name="tiktok_blocked_description">Avaa Saapuneet tai Profiili alla olevista välilehdistä.</string>
+    <string name="instagram_feed_blocked_title">Instagram-videot on estetty</string>
+    <string name="instagram_feed_blocked_description">Avaa Saapuneet tai Profiili alla olevista välilehdistä.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">Les vidéos TikTok sont bloquées</string>
     <string name="tiktok_blocked_description">Utilisez les onglets ci-dessous pour ouvrir la Boîte de réception ou le Profil.</string>
+    <string name="instagram_feed_blocked_title">Les vidéos Instagram sont bloquées</string>
+    <string name="instagram_feed_blocked_description">Utilisez les onglets ci-dessous pour ouvrir la Boîte de réception ou le Profil.</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">TikTok वीडियो ब्लॉक हैं</string>
     <string name="tiktok_blocked_description">इनबॉक्स या प्रोफ़ाइल खोलने के लिए नीचे दिए गए टैब का उपयोग करें।</string>
+    <string name="instagram_feed_blocked_title">Instagram वीडियो ब्लॉक हैं</string>
+    <string name="instagram_feed_blocked_description">इनबॉक्स या प्रोफ़ाइल खोलने के लिए नीचे दिए गए टैब का उपयोग करें।</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">TikTok videozapisi su blokirani</string>
     <string name="tiktok_blocked_description">Upotrijebite kartice na dnu da biste otvorili „Ulazni sandučić” ili „Profil”.</string>
+    <string name="instagram_feed_blocked_title">Instagram videozapisi su blokirani</string>
+    <string name="instagram_feed_blocked_description">Upotrijebite kartice na dnu da biste otvorili „Ulazni sandučić” ili „Profil”.</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">A TikTok-videók blokkolva vannak</string>
     <string name="tiktok_blocked_description">Használd az alábbi füleket a Bejövő üzenetek vagy a Profil megnyitásához.</string>
+    <string name="instagram_feed_blocked_title">Az Instagram-videók blokkolva vannak</string>
+    <string name="instagram_feed_blocked_description">Használd az alábbi füleket a Bejövő üzenetek vagy a Profil megnyitásához.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">I video di TikTok sono bloccati</string>
     <string name="tiktok_blocked_description">Usa le schede in basso per aprire In arrivo o il Profilo.</string>
+    <string name="instagram_feed_blocked_title">I video di Instagram sono bloccati</string>
+    <string name="instagram_feed_blocked_description">Usa le schede in basso per aprire In arrivo o il Profilo.</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">TikTokの動画はブロックされています</string>
     <string name="tiktok_blocked_description">下のタブから「メッセージ」または「プロフィール」を開いてください。</string>
+    <string name="instagram_feed_blocked_title">Instagramの動画はブロックされています</string>
+    <string name="instagram_feed_blocked_description">下のタブから「メッセージ」または「プロフィール」を開いてください。</string>
 </resources>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">TikTok വീഡിയോകൾ ബ്ലോക്ക് ചെയ്‌തിരിക്കുന്നു</string>
     <string name="tiktok_blocked_description">ഇൻബോക്സോ പ്രൊഫൈലോ തുറക്കാൻ താഴെയുള്ള ടാബുകൾ ഉപയോഗിക്കുക.</string>
+    <string name="instagram_feed_blocked_title">Instagram വീഡിയോകൾ ബ്ലോക്ക് ചെയ്‌തിരിക്കുന്നു</string>
+    <string name="instagram_feed_blocked_description">ഇൻബോക്സോ പ്രൊഫൈലോ തുറക്കാൻ താഴെയുള്ള ടാബുകൾ ഉപയോഗിക്കുക.</string>
 </resources>

--- a/app/src/main/res/values-mr/strings.xml
+++ b/app/src/main/res/values-mr/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">TikTok व्हिडिओ ब्लॉक केले आहेत</string>
     <string name="tiktok_blocked_description">इनबॉक्स किंवा प्रोफाइल उघडण्यासाठी खालील टॅब वापरा.</string>
+    <string name="instagram_feed_blocked_title">Instagram व्हिडिओ ब्लॉक केले आहेत</string>
+    <string name="instagram_feed_blocked_description">इनबॉक्स किंवा प्रोफाइल उघडण्यासाठी खालील टॅब वापरा.</string>
 </resources>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">TikTok-videoer er blokkert</string>
     <string name="tiktok_blocked_description">Bruk fanene nedenfor for å åpne Innboks eller Profil.</string>
+    <string name="instagram_feed_blocked_title">Instagram-videoer er blokkert</string>
+    <string name="instagram_feed_blocked_description">Bruk fanene nedenfor for å åpne Innboks eller Profil.</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">TikTok-video\'s zijn geblokkeerd</string>
     <string name="tiktok_blocked_description">Gebruik de onderstaande tabbladen om Inbox of Profiel te openen.</string>
+    <string name="instagram_feed_blocked_title">Instagram-video\'s zijn geblokkeerd</string>
+    <string name="instagram_feed_blocked_description">Gebruik de onderstaande tabbladen om Inbox of Profiel te openen.</string>
 </resources>

--- a/app/src/main/res/values-nn-rNO/strings.xml
+++ b/app/src/main/res/values-nn-rNO/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">TikTok-videoar er blokkerte</string>
     <string name="tiktok_blocked_description">Bruk fanene nedanfor til å opne Innboks eller Profil.</string>
+    <string name="instagram_feed_blocked_title">Instagram-videoar er blokkerte</string>
+    <string name="instagram_feed_blocked_description">Bruk fanene nedanfor til å opne Innboks eller Profil.</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">Filmy na TikToku są zablokowane</string>
     <string name="tiktok_blocked_description">Użyj zakładek na dole, aby otworzyć „Skrzynkę odbiorczą” lub „Profil”.</string>
+    <string name="instagram_feed_blocked_title">Filmy na Instagramie są zablokowane</string>
+    <string name="instagram_feed_blocked_description">Użyj zakładek na dole, aby otworzyć „Skrzynkę odbiorczą” lub „Profil”.</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">Os vídeos do TikTok estão bloqueados</string>
     <string name="tiktok_blocked_description">Use as abas abaixo para abrir a Caixa de entrada ou o Perfil.</string>
+    <string name="instagram_feed_blocked_title">Os vídeos do Instagram estão bloqueados</string>
+    <string name="instagram_feed_blocked_description">Use as abas abaixo para abrir a Caixa de entrada ou o Perfil.</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">Os vídeos do TikTok estão bloqueados</string>
     <string name="tiktok_blocked_description">Usa os separadores abaixo para abrir a Caixa de entrada ou o Perfil.</string>
+    <string name="instagram_feed_blocked_title">Os vídeos do Instagram estão bloqueados</string>
+    <string name="instagram_feed_blocked_description">Usa os separadores abaixo para abrir a Caixa de entrada ou o Perfil.</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">Videoclipurile TikTok sunt blocate</string>
     <string name="tiktok_blocked_description">Folosește filele de mai jos pentru a deschide Mesaje primite sau Profil.</string>
+    <string name="instagram_feed_blocked_title">Videoclipurile Instagram sunt blocate</string>
+    <string name="instagram_feed_blocked_description">Folosește filele de mai jos pentru a deschide Mesaje primite sau Profil.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">Видео в TikTok заблокированы</string>
     <string name="tiktok_blocked_description">Используйте вкладки внизу, чтобы открыть «Входящие» или «Профиль».</string>
+    <string name="instagram_feed_blocked_title">Видео в Instagram заблокированы</string>
+    <string name="instagram_feed_blocked_description">Используйте вкладки внизу, чтобы открыть «Входящие» или «Профиль».</string>
 </resources>

--- a/app/src/main/res/values-sk-rSK/strings.xml
+++ b/app/src/main/res/values-sk-rSK/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">Videá na TikToku sú zablokované</string>
     <string name="tiktok_blocked_description">Pomocou kariet dole otvorte „Doručenú poštu“ alebo „Profil“.</string>
+    <string name="instagram_feed_blocked_title">Videá na Instagrame sú zablokované</string>
+    <string name="instagram_feed_blocked_description">Pomocou kariet dole otvorte „Doručenú poštu“ alebo „Profil“.</string>
 </resources>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">TikTok видео-снимци су блокирани</string>
     <string name="tiktok_blocked_description">Користите картице на дну да бисте отворили „Пријемно сандуче” или „Профил”.</string>
+    <string name="instagram_feed_blocked_title">Instagram видео-снимци су блокирани</string>
+    <string name="instagram_feed_blocked_description">Користите картице на дну да бисте отворили „Пријемно сандуче” или „Профил”.</string>
 </resources>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">TikTok-videor är blockerade</string>
     <string name="tiktok_blocked_description">Använd flikarna nedan för att öppna Inkorg eller Profil.</string>
+    <string name="instagram_feed_blocked_title">Instagram-videor är blockerade</string>
+    <string name="instagram_feed_blocked_description">Använd flikarna nedan för att öppna Inkorg eller Profil.</string>
 </resources>

--- a/app/src/main/res/values-ta-rIN/strings.xml
+++ b/app/src/main/res/values-ta-rIN/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">TikTok வீடியோக்கள் முடக்கப்பட்டுள்ளன</string>
     <string name="tiktok_blocked_description">இன்பாக்ஸ் அல்லது சுயவிவரத்தைத் திறக்க கீழே உள்ள தாவல்களைப் பயன்படுத்தவும்.</string>
+    <string name="instagram_feed_blocked_title">Instagram வீடியோக்கள் முடக்கப்பட்டுள்ளன</string>
+    <string name="instagram_feed_blocked_description">இன்பாக்ஸ் அல்லது சுயவிவரத்தைத் திறக்க கீழே உள்ள தாவல்களைப் பயன்படுத்தவும்.</string>
 </resources>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">TikTok videoları engellendi</string>
     <string name="tiktok_blocked_description">Gelen Kutusunu veya Profili açmak için aşağıdaki sekmeleri kullanın.</string>
+    <string name="instagram_feed_blocked_title">Instagram videoları engellendi</string>
+    <string name="instagram_feed_blocked_description">Gelen Kutusunu veya Profili açmak için aşağıdaki sekmeleri kullanın.</string>
 </resources>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">Відео в TikTok заблоковано</string>
     <string name="tiktok_blocked_description">Використовуйте вкладки внизу, щоб відкрити «Вхідні» або «Профіль».</string>
+    <string name="instagram_feed_blocked_title">Відео в Instagram заблоковано</string>
+    <string name="instagram_feed_blocked_description">Використовуйте вкладки внизу, щоб відкрити «Вхідні» або «Профіль».</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">Video TikTok đã bị chặn</string>
     <string name="tiktok_blocked_description">Sử dụng các tab bên dưới để mở Hộp thư hoặc Hồ sơ.</string>
+    <string name="instagram_feed_blocked_title">Video Instagram đã bị chặn</string>
+    <string name="instagram_feed_blocked_description">Sử dụng các tab bên dưới để mở Hộp thư hoặc Hồ sơ.</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">TikTok 视频已拦截</string>
     <string name="tiktok_blocked_description">使用下方的标签打开“收件箱”或“个人资料”。</string>
+    <string name="instagram_feed_blocked_title">Instagram 视频已拦截</string>
+    <string name="instagram_feed_blocked_description">使用下方的标签打开“收件箱”或“个人资料”。</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -20,4 +20,6 @@
     <string name="app_name">Scrolless</string>
     <string name="tiktok_blocked_title">TikTok 影片已被封鎖</string>
     <string name="tiktok_blocked_description">使用下方的分頁開啟「收件匣」或「個人資料」。</string>
+    <string name="instagram_feed_blocked_title">Instagram 影片已被封鎖</string>
+    <string name="instagram_feed_blocked_description">使用下方的分頁開啟「收件匣」或「個人資料」。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,4 +21,6 @@
     <string name="timer_default_value" translatable="false">00:00</string>
     <string name="tiktok_blocked_title">TikTok videos are blocked</string>
     <string name="tiktok_blocked_description">Use the tabs below to open Inbox or Profile.</string>
+    <string name="instagram_feed_blocked_title">Instagram videos are blocked</string>
+    <string name="instagram_feed_blocked_description">Use the tabs below to open Inbox or Profile.</string>
 </resources>

--- a/app/src/test/java/com/scrolless/app/accessibility/ContentCoverTest.kt
+++ b/app/src/test/java/com/scrolless/app/accessibility/ContentCoverTest.kt
@@ -34,10 +34,10 @@ class ContentCoverTest {
     private val cover = ContentCover(ContentCoverTarget.Window(12, 0, bounds), 1, 2)
 
     @Test
-    fun `both TikTok variants have cover detectors - other apps are unchanged`() {
+    fun `Instagram and both TikTok variants have cover detectors`() {
         BlockableApp.entries.forEach { app ->
             val resolved = ResolvedBlockableApp(app, app.getPackageIds().first())
-            if (app in setOf(BlockableApp.TIKTOK, BlockableApp.TIKTOK_LITE)) {
+            if (app in setOf(BlockableApp.REELS, BlockableApp.TIKTOK, BlockableApp.TIKTOK_LITE)) {
                 assertNotNull(app.coverDetector)
                 assertEquals(app, app.coverDetector!!.app)
                 assertSame(app.coverDetector, resolved.coverDetector)
@@ -95,6 +95,7 @@ class ContentCoverTest {
     fun `backend changes recreate the view while geometry changes only resize or reattach it`() {
         assertFalse(cover.copy(target = ContentCoverTarget.Screen(bounds)).canReuseView(cover))
         assertTrue(cover.canReuseView(cover))
+        assertFalse(cover.copy(passThroughTouches = true).canReuseView(cover))
         assertTrue(cover.copy(target = ContentCoverTarget.Window(15, 1, bounds.copy(right = 900))).canReuseView(cover))
     }
 

--- a/app/src/test/java/com/scrolless/app/accessibility/FeedContentScanQueueTest.kt
+++ b/app/src/test/java/com/scrolless/app/accessibility/FeedContentScanQueueTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2026 Scrolless
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.scrolless.app.accessibility
+
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FeedContentScanQueueTest {
+    private val main = QueuedDispatcher()
+    private val worker = QueuedDispatcher()
+    private val job = Job()
+    private val results = mutableListOf<ContentScanner.Result>()
+    private val queue = FeedContentScanQueue(CoroutineScope(job + main), {
+        assertTrue(main.executing)
+        results += it
+    }, worker)
+    private val result = ContentScanner.Result(null, false, true, null)
+
+    @Test
+    fun `scans run on worker and bursts keep only the latest pending scan`() {
+        val executed = mutableListOf<Int>()
+        fun submit(id: Int) = queue.submit {
+            assertTrue(worker.executing)
+            executed += id
+            result
+        }
+        submit(1)
+        main.runNext()
+        submit(2)
+        submit(3)
+        assertTrue(executed.isEmpty())
+        assertEquals(1, worker.size)
+        worker.runNext()
+        assertTrue(results.isEmpty())
+        main.runNext()
+        assertEquals(listOf(result), results)
+        assertEquals(1, worker.size)
+        worker.runNext()
+        main.runNext()
+        assertEquals(listOf(1, 3), executed)
+        assertEquals(listOf(result, result), results)
+        assertEquals(0, worker.size)
+    }
+
+    @Test
+    fun `navigation rejects in-flight results and clears pending scans`() {
+        queue.submit { result }
+        main.runNext()
+        queue.submit { error("Obsolete pending scan must not execute") }
+        queue.invalidate()
+        worker.runNext()
+        main.runNext()
+        assertTrue(results.isEmpty())
+        assertEquals(0, worker.size)
+        queue.submit { result }
+        main.runNext()
+        worker.runNext()
+        main.runNext()
+        assertEquals(listOf(result), results)
+    }
+
+    @Test
+    fun `new request waits for an invalidated scan without overlapping workers`() {
+        queue.submit { result.copy(rootAvailable = false) }
+        main.runNext()
+        queue.invalidate()
+        queue.submit { result }
+        assertEquals(1, worker.size)
+        worker.runNext()
+        main.runNext()
+        assertTrue(results.isEmpty())
+        worker.runNext()
+        main.runNext()
+        assertEquals(listOf(result), results)
+    }
+
+    @Test
+    fun `service destruction prevents result delivery`() {
+        queue.submit { result }
+        main.runNext()
+        worker.runNext()
+        job.cancel()
+        main.runNext()
+        assertTrue(results.isEmpty())
+    }
+
+    private class QueuedDispatcher : CoroutineDispatcher() {
+        private val tasks = ArrayDeque<Runnable>()
+        var executing = false
+            private set
+        val size get() = tasks.size
+
+        override fun dispatch(context: CoroutineContext, block: Runnable) {
+            tasks.addLast(block)
+        }
+
+        fun runNext() {
+            executing = true
+            try {
+                tasks.removeFirst().run()
+            } finally {
+                executing = false
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/scrolless/app/accessibility/InstagramFeedScreenDetectorTest.kt
+++ b/app/src/test/java/com/scrolless/app/accessibility/InstagramFeedScreenDetectorTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2026 Scrolless
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.scrolless.app.accessibility
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class InstagramFeedScreenDetectorTest {
+    private val home = ContentCoverNode("feed_tab", ContentBounds(0, 2163, 216, 2298), true, isSelected = true)
+    private val video = ContentCoverNode("video_container", ContentBounds(0, 287, 1080, 2066), true)
+
+    @Test
+    fun `covers the inline video and retains it while occluded`() {
+        assertEquals(listOf(video.bounds), InstagramFeedScreenDetector.coverBounds(listOf(home, video)))
+        val hidden = video.copy(isVisible = false)
+        assertEquals(listOf(video.bounds), InstagramFeedScreenDetector.coverBounds(listOf(home, hidden), listOf(video.bounds)))
+        assertTrue(InstagramFeedScreenDetector.coverBounds(listOf(home, hidden)).isEmpty())
+        assertTrue(InstagramFeedScreenDetector.coverBounds(listOf(home), listOf(video.bounds)).isEmpty())
+    }
+
+    @Test
+    fun `photos and screens outside Home do not get feed covers`() {
+        assertTrue(InstagramFeedScreenDetector.coverBounds(listOf(home, video.copy(viewId = "media_group"))).isEmpty())
+        assertTrue(InstagramFeedScreenDetector.coverBounds(listOf(video)).isEmpty())
+        assertTrue(InstagramFeedScreenDetector.coverBounds(listOf(home.copy(isVisible = false), video)).isEmpty())
+        assertTrue(InstagramFeedScreenDetector.coverBounds(listOf(home.copy(isSelected = false), video), listOf(video.bounds)).isEmpty())
+        val viewer = video.copy(viewId = "clips_viewer_view_pager")
+        assertTrue(InstagramFeedScreenDetector.coverBounds(listOf(home, video, viewer)).isEmpty())
+        assertEquals(listOf(video.bounds), InstagramFeedScreenDetector.coverBounds(listOf(home, video, viewer.copy(isVisible = false))))
+    }
+
+    @Test
+    fun `photo carousels with music are not standalone Reels`() {
+        val photo = listOf(home) + listOf(
+            "media_group", "carousel_media_group", "carousel_video_media_group",
+            "carousel_video_image", "video_states",
+        ).map { video.copy(viewId = it) }
+        assertTrue(InstagramFeedScreenDetector.coverBounds(photo).isEmpty())
+        assertTrue(InstagramFeedScreenDetector.coverBounds(photo, listOf(video.bounds)).isEmpty())
+    }
+
+    @Test
+    fun `uses clipped video bounds and ignores empty players`() {
+        val clipped = video.copy(bounds = ContentBounds(0, 97, 1080, 400))
+        val empty = video.copy(bounds = ContentBounds(0, 97, 1080, 97))
+        assertEquals(listOf(clipped.bounds), InstagramFeedScreenDetector.coverBounds(listOf(home, empty, clipped)))
+        assertTrue(InstagramFeedScreenDetector.coverBounds(listOf(home, empty)).isEmpty())
+        assertEquals(listOf(clipped.bounds, video.bounds), InstagramFeedScreenDetector.coverBounds(listOf(home, clipped, video)))
+    }
+    @Test
+    fun `retains both covered videos and drops a removed post`() {
+        val first = video.copy(bounds = ContentBounds(0, 100, 1080, 700))
+        val second = video.copy(bounds = ContentBounds(0, 1000, 1080, 2100))
+        val regions = listOf(first.bounds, second.bounds)
+        assertEquals(regions, InstagramFeedScreenDetector.coverBounds(listOf(home, first, second)))
+        val hidden = listOf(first, second).map { it.copy(isVisible = false) }
+        assertEquals(regions, InstagramFeedScreenDetector.coverBounds(listOf(home) + hidden, regions))
+        assertEquals(listOf(second.bounds), InstagramFeedScreenDetector.coverBounds(listOf(home, hidden.last()), regions))
+    }
+}

--- a/app/src/test/java/com/scrolless/app/accessibility/TikTokScreenDetectorTest.kt
+++ b/app/src/test/java/com/scrolless/app/accessibility/TikTokScreenDetectorTest.kt
@@ -19,7 +19,7 @@ package com.scrolless.app.accessibility
 import com.scrolless.app.core.model.BlockableApp
 import javax.xml.parsers.DocumentBuilderFactory
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.w3c.dom.Element
 
@@ -28,17 +28,17 @@ class TikTokScreenDetectorTest {
 
     @Test
     fun `captured feed covers the player but not native navigation`() {
-        assertEquals(ContentBounds(0, 0, 1080, 2160), detector.coverBounds(fixture("home")))
+        assertEquals(listOf(ContentBounds(0, 0, 1080, 2160)), detector.coverBounds(fixture("home")))
     }
 
     @Test
     fun `captured DM video covers the player correctly`() {
-        assertEquals(ContentBounds(0, 97, 1080, 2160), detector.coverBounds(fixture("dm_video")))
+        assertEquals(listOf(ContentBounds(0, 97, 1080, 2160)), detector.coverBounds(fixture("dm_video")))
     }
 
     @Test
     fun `captured Inbox contains no blockable video`() {
-        assertNull(detector.coverBounds(fixture("inbox")))
+        assertTrue(detector.coverBounds(fixture("inbox")).isEmpty())
     }
 
     @Test
@@ -46,7 +46,7 @@ class TikTokScreenDetectorTest {
         val nodes = fixture("home").map {
             if (it.viewId == "player_view") it.copy(isVisible = false) else it
         }
-        assertNull(detector.coverBounds(nodes))
+        assertTrue(detector.coverBounds(nodes).isEmpty())
     }
 
     @Test
@@ -55,19 +55,19 @@ class TikTokScreenDetectorTest {
         val nodes = fixture("home").map {
             if (it.viewId == "player_view") it.copy(isVisible = false) else it
         }
-        assertEquals(player.bounds, detector.coverBounds(nodes, activeCoverBounds = player.bounds))
+        assertEquals(listOf(player.bounds), detector.coverBounds(nodes, activeCoverBounds = listOf(player.bounds)))
     }
 
     @Test
     fun `offscreen empty players do not match`() {
         val nodes = listOf(ContentCoverNode("player_view", ContentBounds(0, 2160, 1080, 2160), true))
-        assertNull(detector.coverBounds(nodes))
+        assertTrue(detector.coverBounds(nodes).isEmpty())
     }
 
     @Test
     fun `visible videos opened from a native tab still get detected`() {
         val player = fixture("home").first { it.viewId == "player_view" }
-        assertEquals(player.bounds, detector.coverBounds(fixture("inbox") + player))
+        assertEquals(listOf(player.bounds), detector.coverBounds(fixture("inbox") + player))
     }
 
     /** Verifies Lite uses its own player bounds and keeps the cover when it obscures that player. */
@@ -76,11 +76,11 @@ class TikTokScreenDetectorTest {
         val lite = TikTokScreenDetector(BlockableApp.TIKTOK_LITE)
         val bounds = ContentBounds(0, 97, 1080, 2160)
         val player = ContentCoverNode("simplayer_api_player_view", bounds, true)
-        assertEquals(bounds, lite.coverBounds(listOf(player)))
-        assertEquals(bounds, lite.coverBounds(listOf(player.copy(isVisible = false)), bounds))
-        assertNull(lite.coverBounds(listOf(player.copy(isVisible = false))))
-        assertNull(lite.coverBounds(listOf(player.copy(viewId = "player_view"))))
-        assertNull(lite.coverBounds(emptyList(), bounds))
+        assertEquals(listOf(bounds), lite.coverBounds(listOf(player)))
+        assertEquals(listOf(bounds), lite.coverBounds(listOf(player.copy(isVisible = false)), listOf(bounds)))
+        assertTrue(lite.coverBounds(listOf(player.copy(isVisible = false))).isEmpty())
+        assertTrue(lite.coverBounds(listOf(player.copy(viewId = "player_view"))).isEmpty())
+        assertTrue(lite.coverBounds(emptyList(), listOf(bounds)).isEmpty())
     }
 
     private fun fixture(name: String): List<ContentCoverNode> {

--- a/app/src/test/java/com/scrolless/app/ui/overlay/ContentCoverTargetTest.kt
+++ b/app/src/test/java/com/scrolless/app/ui/overlay/ContentCoverTargetTest.kt
@@ -63,7 +63,16 @@ class ContentCoverTargetTest {
     fun `window local player bounds are used directly as the cover target`() {
         val localPlayer = ContentBounds(0, 0, 800, 1400)
         val nodes = listOf(ContentCoverNode("player_view", localPlayer, true))
-        val target = window.copy(bounds = TikTokScreenDetector(BlockableApp.TIKTOK).coverBounds(nodes)!!)
+        val target = window.copy(bounds = TikTokScreenDetector(BlockableApp.TIKTOK).coverBounds(nodes).single())
         assertEquals(localPlayer, target.bounds)
+    }
+    @Test
+    fun `moving or removing a second video updates the screen cover`() {
+        val first = ContentBounds(0, 100, 1080, 700)
+        val second = ContentBounds(0, 1000, 1080, 2100)
+        val previous = ContentCoverTarget.Screen(listOf(first, second))
+        assertFalse(previous.needsUpdate(previous, refreshAttachment = false))
+        assertTrue(ContentCoverTarget.Screen(listOf(first, second.copy(top = 900))).needsUpdate(previous, false))
+        assertTrue(ContentCoverTarget.Screen(first).needsUpdate(previous, false))
     }
 }

--- a/app/src/test/java/com/scrolless/app/ui/overlay/FeedContentCoverViewTest.kt
+++ b/app/src/test/java/com/scrolless/app/ui/overlay/FeedContentCoverViewTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2026 Scrolless
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.scrolless.app.ui.overlay
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.view.View
+import com.scrolless.app.accessibility.ContentBounds
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class FeedContentCoverViewTest {
+    @Test
+    @GraphicsMode(GraphicsMode.Mode.NATIVE)
+    fun `message stays centered within the video when its position changes`() {
+        val view = FeedContentCoverView(RuntimeEnvironment.getApplication())
+        val viewport = ContentBounds(0, 100, 1080, 2100)
+        val cover = ContentCover(
+            ContentCoverTarget.Window(1, 0, viewport, listOf(ContentBounds(0, 300, 1080, 1800))),
+            android.R.string.ok,
+            android.R.string.cancel,
+            passThroughTouches = true,
+        )
+        view.layout(0, 0, 1080, 2340)
+        fun textRows(next: ContentCover): Set<Int> {
+            view.update(next)
+            val bitmap = Bitmap.createBitmap(1080, 2340, Bitmap.Config.ARGB_8888)
+            view.draw(Canvas(bitmap))
+            return (100 until 2100).filterTo(mutableSetOf()) { y ->
+                (0 until 1080).any { x -> bitmap.getPixel(x, y) == Color.WHITE }
+            }
+        }
+        val before = textRows(cover)
+        val after = textRows(cover.copy(target = ContentCoverTarget.Window(1, 0, viewport, listOf(ContentBounds(0, 500, 1080, 2000)))))
+        assertTrue(before.isNotEmpty())
+        assertEquals(before.map { it + 200 }.toSet(), after)
+    }
+
+    @Test
+    fun `scroll updates keep the overlay size fixed without requesting layout`() {
+        val view = FeedContentCoverView(RuntimeEnvironment.getApplication())
+        val cover = ContentCover(
+            ContentCoverTarget.Screen(ContentBounds(0, 300, 1080, 2000)),
+            android.R.string.ok,
+            android.R.string.cancel,
+            passThroughTouches = true,
+        )
+        view.update(cover)
+        view.measure(
+            View.MeasureSpec.makeMeasureSpec(1080, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(2340, View.MeasureSpec.EXACTLY),
+        )
+        view.layout(0, 0, 1080, 2340)
+        view.update(cover.copy(target = ContentCoverTarget.Screen(ContentBounds(0, 97, 1080, 800))))
+        assertFalse(view.isLayoutRequested)
+        assertEquals(1080, view.width)
+        assertEquals(2340, view.height)
+    }
+    @Test
+    @GraphicsMode(GraphicsMode.Mode.NATIVE)
+    fun `draws both videos with a transparent gap and clears a removed video`() {
+        val view = FeedContentCoverView(RuntimeEnvironment.getApplication())
+        val first = ContentBounds(0, 100, 1080, 700)
+        val second = ContentBounds(0, 1000, 800, 2100)
+        val cover = ContentCover(
+            ContentCoverTarget.Screen(listOf(first, second)),
+            android.R.string.ok,
+            android.R.string.cancel,
+            passThroughTouches = true,
+        )
+        view.layout(0, 0, 1080, 2340)
+        view.update(cover)
+        val bitmap = Bitmap.createBitmap(1080, 2340, Bitmap.Config.ARGB_8888)
+        view.draw(Canvas(bitmap))
+        assertEquals(255, Color.alpha(bitmap.getPixel(10, 200)))
+        assertEquals(255, Color.alpha(bitmap.getPixel(10, 1100)))
+        assertEquals(0, Color.alpha(bitmap.getPixel(10, 800)))
+        assertEquals(0, Color.alpha(bitmap.getPixel(900, 1100)))
+        view.update(cover.copy(target = ContentCoverTarget.Screen(first)))
+        bitmap.eraseColor(Color.TRANSPARENT)
+        view.draw(Canvas(bitmap))
+        assertEquals(255, Color.alpha(bitmap.getPixel(10, 200)))
+        assertEquals(0, Color.alpha(bitmap.getPixel(10, 1100)))
+    }
+}

--- a/app/src/test/java/com/scrolless/app/ui/overlay/FeedScrollMotionTest.kt
+++ b/app/src/test/java/com/scrolless/app/ui/overlay/FeedScrollMotionTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2026 Scrolless
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.scrolless.app.ui.overlay
+
+import com.scrolless.app.accessibility.ContentBounds
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class FeedScrollMotionTest {
+    private val motion = FeedScrollMotion()
+    private val viewport = ContentBounds(0, 100, 1080, 2100)
+
+    @Test
+    fun `pixel deltas drive bounded motion between layout samples`() {
+        motion.onScroll(150, 1000)
+        motion.onScroll(162, 1108)
+        assertEquals(-60, motion.offset(1108, 1148))
+        assertEquals(-120, motion.offset(1108, 1228))
+        // A newer layout is already farther along the scroll; do not apply the old displacement again.
+        assertEquals(-15, motion.offset(1138, 1148))
+        assertEquals(0, motion.offset(0, 1148))
+    }
+
+    @Test
+    fun `stops and reversals do not keep the previous direction`() {
+        motion.onScroll(100, 1000)
+        motion.onScroll(-100, 1100)
+        assertEquals(40, motion.offset(1100, 1140))
+        motion.onScroll(0, 1200)
+        assertEquals(0, motion.offset(1200, 1240))
+        motion.onScroll(100, 1300)
+        assertEquals(0, motion.offset(1300, 1460))
+        assertFalse(motion.isMoving(1460))
+    }
+
+    @Test
+    fun `navigation and out of order events cannot revive old velocity`() {
+        motion.onScroll(100, 1000)
+        motion.onScroll(-1000, 900)
+        assertEquals(-40, motion.offset(1000, 1040))
+        motion.reset()
+        assertEquals(0, motion.offset(1000, 1040))
+        assertFalse(motion.isMoving(1040))
+    }
+
+    @Test
+    fun `partly hidden videos stay covered as more of them enters the viewport`() {
+        val bottomClipped = ContentBounds(0, 1500, 1080, 2100)
+        assertEquals(ContentBounds(0, 1400, 1080, 2100), motion.project(bottomClipped, viewport, -100))
+        val topClipped = ContentBounds(0, 100, 1080, 600)
+        assertEquals(ContentBounds(0, 100, 1080, 700), motion.project(topClipped, viewport, 100))
+    }
+
+    @Test
+    fun `predicted rectangles stay inside the feed and leave navigation clear`() {
+        val video = ContentBounds(0, 200, 1080, 2000)
+        assertEquals(ContentBounds(0, 100, 1080, 1800), motion.project(video, viewport, -200))
+        assertEquals(ContentBounds(0, 400, 1080, 2100), motion.project(video, viewport, 200))
+        assertFalse(motion.project(ContentBounds(0, 100, 1080, 150), viewport, -100).isVisible)
+    }
+}


### PR DESCRIPTION
**STILL Work in Progress**

Just did some vibe coding to see what's possible and what can be done, I will still need to look at every line etc

----

- Add InstagramFeedScreenDetector to detect and cover inline video posts on the Home feed without blocking photo carousels
- Implement FeedContentScanQueue for debounced/asynchronous accessibility feed scans during scrolling
- Add FeedScrollMotion, FeedContentCoverView, and WindowAttachedFeedOverlay to smoothly track feed scroll deltas
- Update ScrollessBlockAccessibilityService to handle TYPE_VIEW_SCROLLED events and pass-through touches for feed covers
- Add localized strings across all supported languages
- Add unit tests for detectors, scroll motion, scan queue, and feed cover views