### PR TITLE
feat: Block Instagram Stories

### DIFF
--- a/app/src/main/java/com/scrolless/app/accessibility/ContentScanner.kt
+++ b/app/src/main/java/com/scrolless/app/accessibility/ContentScanner.kt
@@ -41,6 +41,7 @@ internal class ContentScanner(
     private val service: AccessibilityService,
     private val windowAttachedCover: () -> Boolean,
     private val allowVideosSentByDm: () -> Boolean,
+    private val includeStories: () -> Boolean,
 ) {
     @get:ChecksSdkIntAtLeast(api = Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
     private val useWindowAttachedCover
@@ -256,14 +257,24 @@ internal class ContentScanner(
 
     /** Checks if the screen matches a known video layout, view ID, or label for [blockableApp]. */
     private fun AccessibilityNodeInfo.matchesBlockedContent(blockableApp: ResolvedBlockableApp): Boolean {
-        val detectionMethod = blockableApp.getDetectionMethod()
+        return matchesDetectionMethod(blockableApp, blockableApp.getDetectionMethod(includeStories()))
+    }
+
+    private fun AccessibilityNodeInfo.matchesDetectionMethod(
+        blockableApp: ResolvedBlockableApp,
+        detectionMethod: DetectionMethod,
+    ): Boolean {
+        // Keep mixed layout rules in one tree scan; ID-only alternatives use indexed lookups.
+        if (detectionMethod is DetectionMethod.AnyOf && detectionMethod.detectionMethods.all { it is DetectionMethod.ViewId }) {
+            return detectionMethod.detectionMethods.any { matchesDetectionMethod(blockableApp, it) }
+        }
 
         // View IDs are indexed by Android, so use the platform lookup instead of walking the tree.
         if (detectionMethod is DetectionMethod.ViewId) {
             return hasVisibleViewId(blockableApp.getViewId(detectionMethod))
         }
 
-        return matchesComplexBlockedContent(blockableApp)
+        return matchesComplexBlockedContent(blockableApp, detectionMethod)
     }
 
     /**
@@ -314,9 +325,12 @@ internal class ContentScanner(
     /**
      * Scans the view hierarchy for complex layout patterns. Returns immediately if a fast rule matches.
      */
-    private fun AccessibilityNodeInfo.matchesComplexBlockedContent(blockableApp: ResolvedBlockableApp): Boolean {
+    private fun AccessibilityNodeInfo.matchesComplexBlockedContent(
+        blockableApp: ResolvedBlockableApp,
+        detectionMethod: DetectionMethod,
+    ): Boolean {
         val structuralNodes = mutableListOf<DetectionNode>()
-        val structuralClassNames = blockableApp.getStructuralClassNames()
+        val structuralClassNames = blockableApp.getStructuralClassNames(detectionMethod)
         val nodesToVisit = ArrayDeque<Pair<AccessibilityNodeInfo, Int?>>()
         val rootBounds = android.graphics.Rect().also(::getBoundsInScreen)
         var nextStructuralNodeId = 0
@@ -337,7 +351,7 @@ internal class ContentScanner(
                     isSelected = node.isSelected,
                 )
 
-                if (blockableApp.matchesFastDetectionNode(fastNode)) {
+                if (blockableApp.matchesFastDetectionNode(fastNode, detectionMethod)) {
                     return true
                 }
 
@@ -365,7 +379,7 @@ internal class ContentScanner(
             }
         }
 
-        return blockableApp.matchesDetectionNodes(structuralNodes)
+        return blockableApp.matchesDetectionNodes(structuralNodes, detectionMethod)
     }
 
     private fun Int.fractionOf(total: Int): Float {

--- a/app/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
+++ b/app/src/main/java/com/scrolless/app/accessibility/ScrollessBlockAccessibilityService.kt
@@ -135,7 +135,7 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
 
     /** Scans the window tree to find target apps, videos, and compute cover coordinates. */
     private val contentScanner by lazy {
-        ContentScanner(this, { isWindowAttachedCoverAllowed }, { currentAllowVideosSentByDm })
+        ContentScanner(this, { isWindowAttachedCoverAllowed }, { currentAllowVideosSentByDm }, { currentIncludeStories })
     }
 
     /**
@@ -152,6 +152,7 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
     private var currentTimerOverlayEnabled: Boolean = false
 
     /** Whether videos received in direct messages are exempt from blocking. */
+    private var currentIncludeStories: Boolean = false
     private var currentAllowVideosSentByDm: Boolean = false
 
     /** Timestamp until which blocking is temporarily paused. */
@@ -262,6 +263,14 @@ class ScrollessBlockAccessibilityService : AccessibilityService() {
         serviceScope.launch {
             userSettingsStore.getAllowVideosSentByDm().collect {
                 currentAllowVideosSentByDm = it
+                refreshDetectedContent()
+                reconsiderVisibleContent()
+            }
+        }
+
+        serviceScope.launch {
+            userSettingsStore.getIncludeStories().collect {
+                currentIncludeStories = it
                 refreshDetectedContent()
                 reconsiderVisibleContent()
             }

--- a/app/src/test/java/com/scrolless/app/accessibility/InstagramStoriesTest.kt
+++ b/app/src/test/java/com/scrolless/app/accessibility/InstagramStoriesTest.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2026 Scrolless
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.scrolless.app.accessibility
+
+import android.accessibilityservice.AccessibilityService
+import android.graphics.Rect
+import android.os.Build
+import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityNodeInfo
+import android.view.accessibility.AccessibilityWindowInfo
+import com.scrolless.app.core.model.BlockableApp
+import com.scrolless.app.core.model.ResolvedBlockableApp
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+import org.robolectric.annotation.RealObject
+import org.robolectric.shadows.ShadowAccessibilityNodeInfo
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28, 35], shadows = [InstagramStoriesTest.IndexedNode::class])
+class InstagramStoriesTest {
+    private var includeStories = false
+    private val service = Robolectric.buildService(TestService::class.java).create().get()
+    private val scanner = ContentScanner(service, { false }, { false }, { includeStories })
+    private val instagram = ResolvedBlockableApp(BlockableApp.REELS, "com.instagram.android")
+
+    @Test
+    fun `Stories opt in can be enabled and disabled during the same viewing session`() {
+        show("reel_viewer_root")
+        assertNull(scanner.findVisibleBlockedContent(instagram))
+        includeStories = true
+        assertNotNull(scanner.findVisibleBlockedContent(instagram))
+        includeStories = false
+        assertNull(scanner.findVisibleBlockedContent(instagram))
+    }
+
+    @Test
+    fun `Reels remain detected regardless of Stories preference`() {
+        show("clips_viewer_view_pager")
+        assertNotNull(scanner.findVisibleBlockedContent(instagram))
+        includeStories = true
+        assertNotNull(scanner.findVisibleBlockedContent(instagram))
+    }
+
+    @Test
+    fun `story tray hidden viewer and another app are not counted`() {
+        includeStories = true
+        show("reel_viewer_profile_picture")
+        assertNull(scanner.findVisibleBlockedContent(instagram))
+        show("reel_viewer_root", visible = false)
+        assertNull(scanner.findVisibleBlockedContent(instagram))
+        show("reel_viewer_root", packageId = "com.example.other")
+        assertNull(scanner.findVisibleBlockedContent(instagram))
+    }
+
+    private fun newNode(): AccessibilityNodeInfo = if (Build.VERSION.SDK_INT >= 33) {
+        AccessibilityNodeInfo()
+    } else {
+        @Suppress("DEPRECATION")
+        AccessibilityNodeInfo.obtain()
+    }
+
+    private fun show(viewId: String, visible: Boolean = true, packageId: String = instagram.packageId) {
+        val root = newNode().apply {
+            packageName = packageId
+            viewIdResourceName = "$packageId:id/$viewId"
+            isVisibleToUser = visible
+            setBoundsInScreen(Rect(0, 97, 1080, 2298))
+        }
+        val window = AccessibilityWindowInfo.obtain()
+        shadowOf(window).apply {
+            setRoot(root)
+            setType(AccessibilityWindowInfo.TYPE_APPLICATION)
+            setActive(true)
+            setFocused(true)
+        }
+        shadowOf(service).apply {
+            setRootInActiveWindow(root)
+            setWindows(listOf(window))
+        }
+    }
+
+    class TestService : AccessibilityService() {
+        override fun onAccessibilityEvent(event: AccessibilityEvent) = Unit
+        override fun onInterrupt() = Unit
+    }
+
+    // Robolectric does not provide Android's indexed view-ID lookup.
+    @Implements(AccessibilityNodeInfo::class)
+    class IndexedNode : ShadowAccessibilityNodeInfo() {
+        @RealObject private lateinit var node: AccessibilityNodeInfo
+
+        // Invoked by Robolectric when Android performs a view-ID lookup.
+        @Suppress("unused")
+        @Implementation
+        fun findAccessibilityNodeInfosByViewId(viewId: String): List<AccessibilityNodeInfo> =
+            if (node.viewIdResourceName == viewId) listOf(node) else emptyList()
+    }
+}

--- a/core/data/src/main/java/com/scrolless/app/core/data/database/ScrollessDatabase.kt
+++ b/core/data/src/main/java/com/scrolless/app/core/data/database/ScrollessDatabase.kt
@@ -34,7 +34,7 @@ import com.scrolless.app.core.data.database.model.UserSettingsEntity
         UserSettingsEntity::class,
         SessionSegmentEntity::class,
     ],
-    version = 10,
+    version = 11,
     exportSchema = false,
 )
 @TypeConverters(LocalDateTypeConverters::class, BlockableAppTypeConverters::class, LocalDateTimeTypeConverters::class)
@@ -302,6 +302,12 @@ abstract class ScrollessDatabase : RoomDatabase() {
                 )
                 db.execSQL("DROP TABLE user_settings_old")
                 db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS index_user_settings_id ON user_settings (id)")
+            }
+        }
+
+        val MIGRATION_10_11 = object : Migration(10, 11) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE user_settings ADD COLUMN include_stories INTEGER NOT NULL DEFAULT 0")
             }
         }
     }

--- a/core/data/src/main/java/com/scrolless/app/core/data/database/dao/UserSettingsDao.kt
+++ b/core/data/src/main/java/com/scrolless/app/core/data/database/dao/UserSettingsDao.kt
@@ -130,6 +130,12 @@ abstract class UserSettingsDao : BaseDao<UserSettingsEntity> {
     @Query("UPDATE user_settings SET pause_duration_millis = :durationMillis WHERE id = 1")
     abstract suspend fun setPauseDuration(durationMillis: Long)
 
+    @Query("SELECT include_stories FROM user_settings WHERE id = 1")
+    abstract fun getIncludeStories(): Flow<Boolean>
+
+    @Query("UPDATE user_settings SET include_stories = :enabled WHERE id = 1")
+    abstract suspend fun setIncludeStories(enabled: Boolean)
+
     @Query("SELECT except_reels_sent_by_dm FROM user_settings WHERE id = 1")
     abstract fun getAllowVideosSentByDm(): Flow<Boolean>
 

--- a/core/data/src/main/java/com/scrolless/app/core/data/database/model/UserSettingsEntity.kt
+++ b/core/data/src/main/java/com/scrolless/app/core/data/database/model/UserSettingsEntity.kt
@@ -55,6 +55,7 @@ data class UserSettingsEntity(
     @ColumnInfo(name = "review_prompt_attempt_count", defaultValue = "0") val reviewPromptAttemptCount: Int = 0,
     @ColumnInfo(name = "review_prompt_last_attempt_at", defaultValue = "0") val reviewPromptLastAttemptAt: Long = 0L,
     @ColumnInfo(name = "pause_duration_millis", defaultValue = "300000") val pauseDurationMillis: Long = 5 * 60 * 1000L,
+    @ColumnInfo(name = "include_stories", defaultValue = "0") val includeStories: Boolean = false,
     @ColumnInfo(name = "except_reels_sent_by_dm", defaultValue = "0") val allowVideosSentByDm: Boolean = false,
 )
 

--- a/core/data/src/main/java/com/scrolless/app/core/data/di/DataDiModule.kt
+++ b/core/data/src/main/java/com/scrolless/app/core/data/di/DataDiModule.kt
@@ -70,6 +70,7 @@ object DataDiModule {
                 ScrollessDatabase.MIGRATION_7_8,
                 ScrollessDatabase.MIGRATION_8_9,
                 ScrollessDatabase.MIGRATION_9_10,
+                ScrollessDatabase.MIGRATION_10_11,
             ).fallbackToDestructiveMigration(true) // Not recommended but for now it shouldn't matter
             .fallbackToDestructiveMigrationOnDowngrade(true).addCallback(
                 object : RoomDatabase.Callback() {

--- a/core/data/src/main/java/com/scrolless/app/core/data/repository/UserSettingsStoreImpl.kt
+++ b/core/data/src/main/java/com/scrolless/app/core/data/repository/UserSettingsStoreImpl.kt
@@ -49,9 +49,13 @@ class UserSettingsStoreImpl @Inject constructor(private val userSettingsDao: Use
     private val _pauseUntil = MutableStateFlow(0L)
     private val _firstLaunchAt = MutableStateFlow(-1L)
     private val _pauseDuration = MutableStateFlow(5 * 60 * 1000L)
+    private val _includeStories = MutableStateFlow(false)
     private val _allowVideosSentByDm = MutableStateFlow(false)
 
     init {
+        coroutineScope.launch {
+            userSettingsDao.getIncludeStories().collect { _includeStories.value = it }
+        }
         coroutineScope.launch {
             userSettingsDao.getFirstLaunchAt().collect { _firstLaunchAt.value = it }
         }
@@ -144,6 +148,13 @@ class UserSettingsStoreImpl @Inject constructor(private val userSettingsDao: Use
     override suspend fun setAllowVideosSentByDm(checked: Boolean) {
         _allowVideosSentByDm.value = checked
         userSettingsDao.setAllowVideosSentByDm(checked)
+    }
+
+    override fun getIncludeStories(): Flow<Boolean> = _includeStories
+
+    override suspend fun setIncludeStories(enabled: Boolean) {
+        _includeStories.value = enabled
+        userSettingsDao.setIncludeStories(enabled)
     }
 
     override fun getFirstLaunchAt(): Flow<Long> = _firstLaunchAt

--- a/core/domain/src/main/java/com/scrolless/app/core/model/BlockableApp.kt
+++ b/core/domain/src/main/java/com/scrolless/app/core/model/BlockableApp.kt
@@ -130,10 +130,12 @@ enum class BlockableApp(
     private val detectionMethod: DetectionMethod,
     private val blockAction: ContentBlockAction,
     private val dmExemptionRule: DmExemptionRule? = null,
+    private val storiesDetectionMethod: DetectionMethod? = null,
 ) {
     REELS(
         packageIds = listOf("com.instagram.android"),
         detectionMethod = DetectionMethod.ViewId("clips_viewer_view_pager"),
+        storiesDetectionMethod = DetectionMethod.ViewId("reel_viewer_root"),
         blockAction = ContentBlockAction.PerformGlobalAction(GLOBAL_ACTION_BACK),
         // Instagram DM Reels display sender info and a reply bar, while algorithmic suggestion
         // carousels introduce a "suggested_title" which must forbid the exemption.
@@ -230,7 +232,11 @@ enum class BlockableApp(
 
     fun getBlockAction(): ContentBlockAction = blockAction
 
-    fun getDetectionMethod(): DetectionMethod = detectionMethod
+    fun getDetectionMethod(includeStories: Boolean = false): DetectionMethod = if (includeStories && storiesDetectionMethod != null) {
+        DetectionMethod.AnyOf(listOf(detectionMethod, storiesDetectionMethod))
+    } else {
+        detectionMethod
+    }
 
     fun getDmExemptionRule(): DmExemptionRule? = dmExemptionRule
 
@@ -249,7 +255,7 @@ enum class BlockableApp(
 data class ResolvedBlockableApp(val app: BlockableApp, val packageId: String) {
     val dmExemptionRule: DmExemptionRule? get() = app.getDmExemptionRule()
 
-    fun getDetectionMethod(): DetectionMethod = app.getDetectionMethod()
+    fun getDetectionMethod(includeStories: Boolean = false): DetectionMethod = app.getDetectionMethod(includeStories)
 
     fun getBlockAction(): ContentBlockAction = app.getBlockAction()
 
@@ -257,20 +263,20 @@ data class ResolvedBlockableApp(val app: BlockableApp, val packageId: String) {
 
     fun getViewId(detectionMethod: DetectionMethod.ViewId): String = getViewId(detectionMethod.viewId)
 
-    fun matchesDetectionNodes(nodes: Collection<DetectionNode>): Boolean {
+    fun matchesDetectionNodes(nodes: Collection<DetectionNode>, detectionMethod: DetectionMethod = getDetectionMethod()): Boolean {
         // Group once so nested-layout checks can find children without rescanning the whole list.
         val childrenByParentId = nodes.groupBy(DetectionNode::parentNodeId)
-        return getDetectionMethod().matches(nodes, childrenByParentId)
+        return detectionMethod.matches(nodes, childrenByParentId)
     }
 
     /** Try rules that need only one node. Layout rules still need the full set of related nodes. */
-    fun matchesFastDetectionNode(node: DetectionNode): Boolean {
-        return getDetectionMethod().matchesFastNode(node)
+    fun matchesFastDetectionNode(node: DetectionNode, detectionMethod: DetectionMethod = getDetectionMethod()): Boolean {
+        return detectionMethod.matchesFastNode(node)
     }
 
     // Tell the screen scanner which view types matter, so it can skip unrelated layout details.
-    fun getStructuralClassNames(): Set<String> {
-        return buildSet { getDetectionMethod().collectStructuralClassNames(this) }
+    fun getStructuralClassNames(detectionMethod: DetectionMethod = getDetectionMethod()): Set<String> {
+        return buildSet { detectionMethod.collectStructuralClassNames(this) }
     }
 
     private fun DetectionMethod.matchesFastNode(node: DetectionNode): Boolean {

--- a/core/domain/src/main/java/com/scrolless/app/core/repository/UserSettingsStore.kt
+++ b/core/domain/src/main/java/com/scrolless/app/core/repository/UserSettingsStore.kt
@@ -45,6 +45,9 @@ interface UserSettingsStore {
     fun getAllowVideosSentByDm(): Flow<Boolean>
     suspend fun setAllowVideosSentByDm(checked: Boolean)
 
+    fun getIncludeStories(): Flow<Boolean>
+    suspend fun setIncludeStories(enabled: Boolean)
+
     fun getFirstLaunchAt(): Flow<Long>
     fun getFirstLaunchDate(): Flow<LocalDate?>
 

--- a/feature/settings/src/main/java/com/scrolless/app/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/scrolless/app/feature/settings/SettingsScreen.kt
@@ -82,6 +82,7 @@ fun SettingsScreen(modifier: Modifier = Modifier, onNavigateBack: () -> Unit, vi
         onPauseDurationChange = viewModel::onPauseDurationChange,
         onAllowVideosSentByDmChange = viewModel::onAllowVideosSentByDmChange,
         onTimerOverlayEnabledChange = viewModel::onTimerOverlayEnabledChange,
+        onIncludeStoriesChange = viewModel::onIncludeStoriesChange,
         onNavigateBack = onNavigateBack,
     )
 }
@@ -94,6 +95,7 @@ private fun SettingsScreenContent(
     onPauseDurationChange: (Int) -> Unit,
     onAllowVideosSentByDmChange: (Boolean) -> Unit,
     onTimerOverlayEnabledChange: (Boolean) -> Unit,
+    onIncludeStoriesChange: (Boolean) -> Unit,
     onNavigateBack: () -> Unit,
 ) {
     val sharedTransitionScope = LocalSharedTransitionScope.current
@@ -174,6 +176,16 @@ private fun SettingsScreenContent(
                 AllowVideosSentByDmItem(
                     checked = uiState.allowVideosSentByDm,
                     onCheckedChange = onAllowVideosSentByDmChange,
+                )
+
+                SettingsDivider()
+
+                SettingsSwitchItem(
+                    title = stringResource(R.string.settings_include_stories_title),
+                    description = stringResource(R.string.settings_include_stories_description),
+                    note = stringResource(R.string.settings_include_stories_note),
+                    checked = uiState.includeStories,
+                    onCheckedChange = onIncludeStoriesChange,
                 )
 
                 SettingsDivider()
@@ -394,6 +406,7 @@ private fun SettingsScreenPreview() {
             onNavigateBack = {},
             onAllowVideosSentByDmChange = {},
             onTimerOverlayEnabledChange = {},
+            onIncludeStoriesChange = {},
         )
     }
 }

--- a/feature/settings/src/main/java/com/scrolless/app/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/scrolless/app/feature/settings/SettingsViewModel.kt
@@ -34,11 +34,13 @@ class SettingsViewModel @Inject constructor(private val userSettingsStore: UserS
         userSettingsStore.getPauseDuration(),
         userSettingsStore.getAllowVideosSentByDm(),
         userSettingsStore.getTimerOverlayEnabled(),
-    ) { pauseDurationMillis, allowVideosSentByDm, timerOverlayEnabled ->
+        userSettingsStore.getIncludeStories(),
+    ) { pauseDurationMillis, allowVideosSentByDm, timerOverlayEnabled, includeStories ->
         SettingsUiState(
             pauseDurationMinutes = (pauseDurationMillis / 60_000L).toInt().coerceIn(1, 60),
             allowVideosSentByDm = allowVideosSentByDm,
             timerOverlayEnabled = timerOverlayEnabled,
+            includeStories = includeStories,
         )
     }
         .stateIn(
@@ -46,6 +48,12 @@ class SettingsViewModel @Inject constructor(private val userSettingsStore: UserS
             started = SharingStarted.WhileSubscribed(5_000),
             initialValue = SettingsUiState(),
         )
+
+    fun onIncludeStoriesChange(enabled: Boolean) {
+        viewModelScope.launch {
+            userSettingsStore.setIncludeStories(enabled)
+        }
+    }
 
     fun onPauseDurationChange(minutes: Int) {
         viewModelScope.launch {
@@ -67,6 +75,7 @@ class SettingsViewModel @Inject constructor(private val userSettingsStore: UserS
 }
 
 data class SettingsUiState(
+    val includeStories: Boolean = false,
     val pauseDurationMinutes: Int = 5,
     val allowVideosSentByDm: Boolean = false,
     val timerOverlayEnabled: Boolean = true,

--- a/feature/settings/src/main/res/values-b+sr+Latn/strings.xml
+++ b/feature/settings/src/main/res/values-b+sr+Latn/strings.xml
@@ -31,4 +31,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">Video snimci poslati u DM-ovima</string>
     <string name="settings_show_onscreen_timer_description">Drži plutajući tajmer vidljivim dok gledaš kratke video-zapise.</string>
     <string name="settings_show_onscreen_timer_title">Prikaži tajmer na ekranu</string>
+    <string name="settings_include_stories_title">Uključi priče</string>
+    <string name="settings_include_stories_description">Računaj vreme provedeno u gledanju priča i primeni trenutni režim blokiranja i vremenska ograničenja.</string>
+    <string name="settings_include_stories_note">Trenutno je podržano na Instagram-u.</string>
 </resources>

--- a/feature/settings/src/main/res/values-ca/strings.xml
+++ b/feature/settings/src/main/res/values-ca/strings.xml
@@ -30,4 +30,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">Vídeos enviats per missatges directes</string>
     <string name="settings_show_onscreen_timer_description">Mantén visible un temporitzador flotant mentre mires vídeos curts.</string>
     <string name="settings_show_onscreen_timer_title">Mostra el temporitzador a la pantalla</string>
+    <string name="settings_include_stories_title">Inclou les històries</string>
+    <string name="settings_include_stories_description">Compta el temps que passes veient històries i aplica el mode de bloqueig i els límits actuals.</string>
+    <string name="settings_include_stories_note">Actualment disponible a Instagram.</string>
 </resources>

--- a/feature/settings/src/main/res/values-cs/strings.xml
+++ b/feature/settings/src/main/res/values-cs/strings.xml
@@ -32,4 +32,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">Videa odeslaná v DMs</string>
     <string name="settings_show_onscreen_timer_description">Při sledování krátkých videí ponechat viditelný plovoucí časovač.</string>
     <string name="settings_show_onscreen_timer_title">Zobrazit časovač na obrazovce</string>
+    <string name="settings_include_stories_title">Zahrnout příběhy</string>
+    <string name="settings_include_stories_description">Započítávat čas strávený sledováním příběhů a používat aktuální režim blokování a limity.</string>
+    <string name="settings_include_stories_note">Zatím podporováno na Instagramu.</string>
 </resources>

--- a/feature/settings/src/main/res/values-de/strings.xml
+++ b/feature/settings/src/main/res/values-de/strings.xml
@@ -30,4 +30,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">In DMs gesendete Videos</string>
     <string name="settings_show_onscreen_timer_description">Beim Ansehen von Kurzvideos einen schwebenden Timer sichtbar lassen.</string>
     <string name="settings_show_onscreen_timer_title">Bildschirmtimer anzeigen</string>
+    <string name="settings_include_stories_title">Storys einbeziehen</string>
+    <string name="settings_include_stories_description">Erfasse die Zeit beim Ansehen von Storys und wende deinen aktuellen Blockiermodus und deine Limits an.</string>
+    <string name="settings_include_stories_note">Derzeit auf Instagram unterstützt.</string>
 </resources>

--- a/feature/settings/src/main/res/values-el/strings.xml
+++ b/feature/settings/src/main/res/values-el/strings.xml
@@ -30,4 +30,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">Βίντεο που αποστέλλονται σε DM</string>
     <string name="settings_show_onscreen_timer_description">Να εμφανίζεται ένας αιωρούμενος χρονοδιακόπτης κατά την παρακολούθηση σύντομων βίντεο.</string>
     <string name="settings_show_onscreen_timer_title">Εμφάνιση χρονοδιακόπτη στην οθόνη</string>
+    <string name="settings_include_stories_title">Συμπερίληψη ιστοριών</string>
+    <string name="settings_include_stories_description">Μετρήστε τον χρόνο προβολής ιστοριών και εφαρμόστε την τρέχουσα λειτουργία αποκλεισμού και τα όριά σας.</string>
+    <string name="settings_include_stories_note">Προς το παρόν υποστηρίζεται στο Instagram.</string>
 </resources>

--- a/feature/settings/src/main/res/values-es/strings.xml
+++ b/feature/settings/src/main/res/values-es/strings.xml
@@ -30,4 +30,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">Vídeos enviados en mensajes directos</string>
     <string name="settings_show_onscreen_timer_description">Mantén visible un temporizador flotante mientras ves vídeos cortos.</string>
     <string name="settings_show_onscreen_timer_title">Mostrar temporizador en pantalla</string>
+    <string name="settings_include_stories_title">Incluir historias</string>
+    <string name="settings_include_stories_description">Cuenta el tiempo que pasas viendo historias y aplica el modo de bloqueo y los límites actuales.</string>
+    <string name="settings_include_stories_note">Actualmente disponible en Instagram.</string>
 </resources>

--- a/feature/settings/src/main/res/values-fi-rFI/strings.xml
+++ b/feature/settings/src/main/res/values-fi-rFI/strings.xml
@@ -30,4 +30,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">DM-viesteissä lähetetyt videot</string>
     <string name="settings_show_onscreen_timer_description">Pidä kelluva ajastin näkyvissä, kun katsot lyhytvideoita.</string>
     <string name="settings_show_onscreen_timer_title">Näytä ajastin näytöllä</string>
+    <string name="settings_include_stories_title">Sisällytä tarinat</string>
+    <string name="settings_include_stories_description">Laske tarinoiden katseluun käytetty aika ja käytä nykyistä estotilaa ja aikarajoja.</string>
+    <string name="settings_include_stories_note">Tuettu tällä hetkellä Instagramissa.</string>
 </resources>

--- a/feature/settings/src/main/res/values-fr/strings.xml
+++ b/feature/settings/src/main/res/values-fr/strings.xml
@@ -30,4 +30,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">Vidéos envoyées par messages directs</string>
     <string name="settings_show_onscreen_timer_description">Garder un minuteur flottant visible en regardant des vidéos courtes.</string>
     <string name="settings_show_onscreen_timer_title">Afficher le minuteur à l\'écran</string>
+    <string name="settings_include_stories_title">Inclure les stories</string>
+    <string name="settings_include_stories_description">Comptabilisez le temps passé à regarder des stories et appliquez votre mode de blocage et vos limites actuels.</string>
+    <string name="settings_include_stories_note">Actuellement disponible sur Instagram.</string>
 </resources>

--- a/feature/settings/src/main/res/values-hi/strings.xml
+++ b/feature/settings/src/main/res/values-hi/strings.xml
@@ -30,4 +30,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">DMs में भेजे गए वीडियो</string>
     <string name="settings_show_onscreen_timer_description">छोटे वीडियो देखते समय एक फ़्लोटिंग टाइमर दृश्यमान रखें।</string>
     <string name="settings_show_onscreen_timer_title">ऑन-स्क्रीन टाइमर दिखाएँ</string>
+    <string name="settings_include_stories_title">स्टोरीज़ शामिल करें</string>
+    <string name="settings_include_stories_description">स्टोरीज़ देखने में बिताया समय गिनें और अपना मौजूदा ब्लॉकिंग मोड और समय सीमाएँ लागू करें।</string>
+    <string name="settings_include_stories_note">फ़िलहाल Instagram पर उपलब्ध है।</string>
 </resources>

--- a/feature/settings/src/main/res/values-hr/strings.xml
+++ b/feature/settings/src/main/res/values-hr/strings.xml
@@ -31,4 +31,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">Videozapisi poslani u DM-ovima</string>
     <string name="settings_show_onscreen_timer_description">Zadrži plutajući mjerač vremena vidljivim dok gledaš kratke videozapise.</string>
     <string name="settings_show_onscreen_timer_title">Prikaži mjerač vremena na zaslonu</string>
+    <string name="settings_include_stories_title">Uključi priče</string>
+    <string name="settings_include_stories_description">Broji vrijeme provedeno gledajući priče i primijeni trenutačni način blokiranja i ograničenja.</string>
+    <string name="settings_include_stories_note">Trenutačno podržano na Instagramu.</string>
 </resources>

--- a/feature/settings/src/main/res/values-hu/strings.xml
+++ b/feature/settings/src/main/res/values-hu/strings.xml
@@ -30,4 +30,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">DM-ben küldött videók</string>
     <string name="settings_show_onscreen_timer_description">Tartsa láthatóan a lebegő időzítőt rövid videók nézése közben.</string>
     <string name="settings_show_onscreen_timer_title">Képernyőn megjelenő időzítő</string>
+    <string name="settings_include_stories_title">Történetek figyelembevétele</string>
+    <string name="settings_include_stories_description">Számítsa bele a történetek megtekintésével töltött időt, és alkalmazza a jelenlegi blokkolási módot és időkorlátokat.</string>
+    <string name="settings_include_stories_note">Jelenleg az Instagramon támogatott.</string>
 </resources>

--- a/feature/settings/src/main/res/values-it/strings.xml
+++ b/feature/settings/src/main/res/values-it/strings.xml
@@ -30,4 +30,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">Video inviati nei messaggi diretti</string>
     <string name="settings_show_onscreen_timer_description">Mantieni un timer mobile visibile mentre guardi contenuti brevi.</string>
     <string name="settings_show_onscreen_timer_title">Mostra timer sullo schermo</string>
+    <string name="settings_include_stories_title">Includi le storie</string>
+    <string name="settings_include_stories_description">Conteggia il tempo trascorso a guardare le storie e applica la modalità di blocco e i limiti attuali.</string>
+    <string name="settings_include_stories_note">Attualmente disponibile su Instagram.</string>
 </resources>

--- a/feature/settings/src/main/res/values-ja/strings.xml
+++ b/feature/settings/src/main/res/values-ja/strings.xml
@@ -29,4 +29,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">DMで送られた動画</string>
     <string name="settings_show_onscreen_timer_description">ショート動画を視聴中にフローティングタイマーを表示します。</string>
     <string name="settings_show_onscreen_timer_title">画面タイマーを表示</string>
+    <string name="settings_include_stories_title">ストーリーズを含める</string>
+    <string name="settings_include_stories_description">ストーリーズの視聴時間をカウントし、現在のブロックモードと時間制限を適用します。</string>
+    <string name="settings_include_stories_note">現在はInstagramに対応しています。</string>
 </resources>

--- a/feature/settings/src/main/res/values-ml/strings.xml
+++ b/feature/settings/src/main/res/values-ml/strings.xml
@@ -30,4 +30,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">DM-കളിൽ അയച്ച വീഡിയോകൾ</string>
     <string name="settings_show_onscreen_timer_description">ചെറിയ വീഡിയോകൾ കാണുമ്പോൾ ഒരു ഫ്ലോട്ടിംഗ് ടൈമർ ദൃശ്യമാക്കി നിർത്തുക.</string>
     <string name="settings_show_onscreen_timer_title">ഓൺ-സ്ക്രീൻ ടൈമർ കാണിക്കുക</string>
+    <string name="settings_include_stories_title">സ്റ്റോറികൾ ഉൾപ്പെടുത്തുക</string>
+    <string name="settings_include_stories_description">സ്റ്റോറികൾ കാണാൻ ചെലവഴിക്കുന്ന സമയം കണക്കാക്കുകയും നിലവിലെ ബ്ലോക്കിംഗ് മോഡും സമയപരിധികളും പ്രയോഗിക്കുകയും ചെയ്യുക.</string>
+    <string name="settings_include_stories_note">നിലവിൽ Instagram-ൽ ലഭ്യമാണ്.</string>
 </resources>

--- a/feature/settings/src/main/res/values-mr/strings.xml
+++ b/feature/settings/src/main/res/values-mr/strings.xml
@@ -30,4 +30,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">DMs मध्ये पाठवलेले व्हिडिओ</string>
     <string name="settings_show_onscreen_timer_description">लहान व्हिडिओ पाहताना फ्लोटिंग टाइमर दृश्यमान ठेवा.</string>
     <string name="settings_show_onscreen_timer_title">ऑन-स्क्रीन टाइमर दाखवा</string>
+    <string name="settings_include_stories_title">स्टोरीज समाविष्ट करा</string>
+    <string name="settings_include_stories_description">स्टोरीज पाहण्यात घालवलेला वेळ मोजा आणि तुमचा सध्याचा ब्लॉकिंग मोड व वेळेच्या मर्यादा लागू करा.</string>
+    <string name="settings_include_stories_note">सध्या Instagram वर उपलब्ध आहे.</string>
 </resources>

--- a/feature/settings/src/main/res/values-nb-rNO/strings.xml
+++ b/feature/settings/src/main/res/values-nb-rNO/strings.xml
@@ -30,4 +30,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">Videoer sendt i DM-er</string>
     <string name="settings_show_onscreen_timer_description">Hold en flytende tidtaker synlig mens du ser på korte videoer.</string>
     <string name="settings_show_onscreen_timer_title">Vis tidtaker på skjermen</string>
+    <string name="settings_include_stories_title">Inkluder historier</string>
+    <string name="settings_include_stories_description">Tell tiden du bruker på å se historier, og bruk gjeldende blokkeringsmodus og tidsgrenser.</string>
+    <string name="settings_include_stories_note">Støttes foreløpig på Instagram.</string>
 </resources>

--- a/feature/settings/src/main/res/values-nl/strings.xml
+++ b/feature/settings/src/main/res/values-nl/strings.xml
@@ -30,4 +30,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">Video\'s verzonden via DM\'s</string>
     <string name="settings_show_onscreen_timer_description">Houd een zwevende timer zichtbaar tijdens het bekijken van korte video\'s.</string>
     <string name="settings_show_onscreen_timer_title">Toon timer op scherm</string>
+    <string name="settings_include_stories_title">Verhalen meetellen</string>
+    <string name="settings_include_stories_description">Tel de tijd die je besteedt aan het bekijken van verhalen mee en pas je huidige blokkeermodus en tijdslimieten toe.</string>
+    <string name="settings_include_stories_note">Momenteel ondersteund op Instagram.</string>
 </resources>

--- a/feature/settings/src/main/res/values-nn-rNO/strings.xml
+++ b/feature/settings/src/main/res/values-nn-rNO/strings.xml
@@ -30,4 +30,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">Videoar sende i DM-ar</string>
     <string name="settings_show_onscreen_timer_description">Hald ein flytande tidtakar synleg medan du ser på korte videoar.</string>
     <string name="settings_show_onscreen_timer_title">Vis tidtakar på skjermen</string>
+    <string name="settings_include_stories_title">Ta med historier</string>
+    <string name="settings_include_stories_description">Tel tida du bruker på å sjå historier, og bruk gjeldande blokkeringsmodus og tidsgrenser.</string>
+    <string name="settings_include_stories_note">Førebels støtta på Instagram.</string>
 </resources>

--- a/feature/settings/src/main/res/values-pl/strings.xml
+++ b/feature/settings/src/main/res/values-pl/strings.xml
@@ -32,4 +32,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">Filmy wysyłane w wiadomościach prywatnych</string>
     <string name="settings_show_onscreen_timer_description">Utrzymuj widoczny pływający minutnik podczas oglądania krótkich filmów.</string>
     <string name="settings_show_onscreen_timer_title">Pokaż minutnik na ekranie</string>
+    <string name="settings_include_stories_title">Uwzględniaj relacje</string>
+    <string name="settings_include_stories_description">Wliczaj czas spędzony na oglądaniu relacji i stosuj bieżący tryb blokowania oraz limity czasu.</string>
+    <string name="settings_include_stories_note">Obecnie obsługiwane na Instagramie.</string>
 </resources>

--- a/feature/settings/src/main/res/values-pt-rBR/strings.xml
+++ b/feature/settings/src/main/res/values-pt-rBR/strings.xml
@@ -30,4 +30,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">Vídeos enviados em DMs</string>
     <string name="settings_show_onscreen_timer_description">Manter um timer flutuante visível enquanto você assiste a vídeos curtos.</string>
     <string name="settings_show_onscreen_timer_title">Mostrar timer na tela</string>
+    <string name="settings_include_stories_title">Incluir stories</string>
+    <string name="settings_include_stories_description">Contabiliza o tempo vendo stories e aplica o modo de bloqueio e os limites atuais.</string>
+    <string name="settings_include_stories_note">Disponível atualmente no Instagram.</string>
 </resources>

--- a/feature/settings/src/main/res/values-pt/strings.xml
+++ b/feature/settings/src/main/res/values-pt/strings.xml
@@ -30,4 +30,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">Vídeos enviados em DMs</string>
     <string name="settings_show_onscreen_timer_description">Mantenha um temporizador flutuante visível enquanto vê vídeos curtos.</string>
     <string name="settings_show_onscreen_timer_title">Mostrar temporizador no ecrã</string>
+    <string name="settings_include_stories_title">Incluir histórias</string>
+    <string name="settings_include_stories_description">Contabiliza o tempo a ver histórias e aplica o modo de bloqueio e os limites atuais.</string>
+    <string name="settings_include_stories_note">Atualmente disponível no Instagram.</string>
 </resources>

--- a/feature/settings/src/main/res/values-ro/strings.xml
+++ b/feature/settings/src/main/res/values-ro/strings.xml
@@ -31,4 +31,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">Videoclipuri trimise în mesaje directe</string>
     <string name="settings_show_onscreen_timer_description">Păstrează un cronometru plutitor vizibil în timp ce vizionezi videoclipuri scurte.</string>
     <string name="settings_show_onscreen_timer_title">Afișează cronometrul pe ecran</string>
+    <string name="settings_include_stories_title">Include poveștile</string>
+    <string name="settings_include_stories_description">Contorizează timpul petrecut vizionând povești și aplică modul de blocare și limitele actuale.</string>
+    <string name="settings_include_stories_note">Disponibil momentan pe Instagram.</string>
 </resources>

--- a/feature/settings/src/main/res/values-ru/strings.xml
+++ b/feature/settings/src/main/res/values-ru/strings.xml
@@ -32,4 +32,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">Видео, отправленные в личных сообщениях</string>
     <string name="settings_show_onscreen_timer_description">Отображать плавающий таймер во время просмотра коротких видео.</string>
     <string name="settings_show_onscreen_timer_title">Показывать таймер на экране</string>
+    <string name="settings_include_stories_title">Учитывать истории</string>
+    <string name="settings_include_stories_description">Учитывайте время просмотра историй и применяйте текущий режим блокировки и ограничения времени.</string>
+    <string name="settings_include_stories_note">Пока поддерживается только Instagram.</string>
 </resources>

--- a/feature/settings/src/main/res/values-sk-rSK/strings.xml
+++ b/feature/settings/src/main/res/values-sk-rSK/strings.xml
@@ -32,4 +32,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">Videá odoslané v DM</string>
     <string name="settings_show_onscreen_timer_description">Ponechať plávajúci časovač viditeľný pri sledovaní krátkych videí.</string>
     <string name="settings_show_onscreen_timer_title">Zobraziť časovač na obrazovke</string>
+    <string name="settings_include_stories_title">Zahrnúť príbehy</string>
+    <string name="settings_include_stories_description">Započítavať čas strávený sledovaním príbehov a používať aktuálny režim blokovania a časové limity.</string>
+    <string name="settings_include_stories_note">Zatiaľ podporované na Instagrame.</string>
 </resources>

--- a/feature/settings/src/main/res/values-sr/strings.xml
+++ b/feature/settings/src/main/res/values-sr/strings.xml
@@ -31,4 +31,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">Видео снимци послати у DM-овима</string>
     <string name="settings_show_onscreen_timer_description">Држи плутајући тајмер видљивим док гледаш кратке видео-записе.</string>
     <string name="settings_show_onscreen_timer_title">Прикажи тајмер на екрану</string>
+    <string name="settings_include_stories_title">Укључи приче</string>
+    <string name="settings_include_stories_description">Рачунај време проведено у гледању прича и примени тренутни режим блокирања и временска ограничења.</string>
+    <string name="settings_include_stories_note">Тренутно је подржано на Instagram-у.</string>
 </resources>

--- a/feature/settings/src/main/res/values-sv-rSE/strings.xml
+++ b/feature/settings/src/main/res/values-sv-rSE/strings.xml
@@ -30,4 +30,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">Videor skickade i DM</string>
     <string name="settings_show_onscreen_timer_description">Håll en flytande timer synlig när du tittar på kort videoinnehåll.</string>
     <string name="settings_show_onscreen_timer_title">Visa timer på skärmen</string>
+    <string name="settings_include_stories_title">Inkludera händelser</string>
+    <string name="settings_include_stories_description">Räkna tiden du lägger på att titta på händelser och tillämpa ditt nuvarande blockeringsläge och dina tidsgränser.</string>
+    <string name="settings_include_stories_note">Stöds för närvarande på Instagram.</string>
 </resources>

--- a/feature/settings/src/main/res/values-ta-rIN/strings.xml
+++ b/feature/settings/src/main/res/values-ta-rIN/strings.xml
@@ -30,4 +30,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">நேரடிச் செய்திகளில் அனுப்பப்பட்ட வீடியோக்கள்</string>
     <string name="settings_show_onscreen_timer_description">குறுகிய வீடியோக்களைப் பார்க்கும்போது மிதக்கும் டைமரைத் திரையில் தெரியும்படி வைத்திருங்கள்.</string>
     <string name="settings_show_onscreen_timer_title">திரையில் டைமரைக் காட்டு</string>
+    <string name="settings_include_stories_title">ஸ்டோரிகளைச் சேர்க்கவும்</string>
+    <string name="settings_include_stories_description">ஸ்டோரிகளைப் பார்ப்பதில் செலவிடும் நேரத்தைக் கணக்கிட்டு, தற்போதைய தடுப்பு முறையையும் நேர வரம்புகளையும் பயன்படுத்தவும்.</string>
+    <string name="settings_include_stories_note">தற்போது Instagram-இல் ஆதரிக்கப்படுகிறது.</string>
 </resources>

--- a/feature/settings/src/main/res/values-tr-rTR/strings.xml
+++ b/feature/settings/src/main/res/values-tr-rTR/strings.xml
@@ -30,4 +30,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">DM\'lerde gönderilen videolar</string>
     <string name="settings_show_onscreen_timer_description">Kısa videolar izlerken kayan zamanlayıcıyı görünür tut.</string>
     <string name="settings_show_onscreen_timer_title">Ekran zamanlayıcısını göster</string>
+    <string name="settings_include_stories_title">Hikâyeleri dahil et</string>
+    <string name="settings_include_stories_description">Hikâyeleri izlerken geçirilen süreyi say ve mevcut engelleme modunu ve süre sınırlarını uygula.</string>
+    <string name="settings_include_stories_note">Şu anda Instagram desteklenmektedir.</string>
 </resources>

--- a/feature/settings/src/main/res/values-uk-rUA/strings.xml
+++ b/feature/settings/src/main/res/values-uk-rUA/strings.xml
@@ -32,4 +32,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">Відео, надіслані в особистих повідомленнях</string>
     <string name="settings_show_onscreen_timer_description">Залишати плаваючий таймер видимим під час перегляду коротких відео.</string>
     <string name="settings_show_onscreen_timer_title">Показувати таймер на екрані</string>
+    <string name="settings_include_stories_title">Враховувати історії</string>
+    <string name="settings_include_stories_description">Враховуйте час перегляду історій і застосовуйте поточний режим блокування та часові обмеження.</string>
+    <string name="settings_include_stories_note">Наразі підтримується в Instagram.</string>
 </resources>

--- a/feature/settings/src/main/res/values-vi/strings.xml
+++ b/feature/settings/src/main/res/values-vi/strings.xml
@@ -29,4 +29,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">Video được gửi trong tin nhắn trực tiếp</string>
     <string name="settings_show_onscreen_timer_description">Giữ bộ hẹn giờ nổi hiển thị khi xem video ngắn.</string>
     <string name="settings_show_onscreen_timer_title">Hiển thị bộ hẹn giờ trên màn hình</string>
+    <string name="settings_include_stories_title">Bao gồm tin</string>
+    <string name="settings_include_stories_description">Tính thời gian xem tin và áp dụng chế độ chặn cùng giới hạn thời gian hiện tại của bạn.</string>
+    <string name="settings_include_stories_note">Hiện được hỗ trợ trên Instagram.</string>
 </resources>

--- a/feature/settings/src/main/res/values-zh-rCN/strings.xml
+++ b/feature/settings/src/main/res/values-zh-rCN/strings.xml
@@ -29,4 +29,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">私信发送的视频</string>
     <string name="settings_show_onscreen_timer_description">观看短视频内容时，保持浮动计时器可见。</string>
     <string name="settings_show_onscreen_timer_title">显示屏幕悬浮计时器</string>
+    <string name="settings_include_stories_title">包含快拍</string>
+    <string name="settings_include_stories_description">统计浏览快拍所花的时间，并应用当前的屏蔽模式和时间限制。</string>
+    <string name="settings_include_stories_note">目前支持 Instagram。</string>
 </resources>

--- a/feature/settings/src/main/res/values-zh-rTW/strings.xml
+++ b/feature/settings/src/main/res/values-zh-rTW/strings.xml
@@ -29,4 +29,7 @@
     <string name="settings_allow_videos_sent_by_dms_title">私訊中傳送的影片</string>
     <string name="settings_show_onscreen_timer_description">觀看短影音內容時，保持浮動計時器可見。</string>
     <string name="settings_show_onscreen_timer_title">顯示螢幕浮動計時器</string>
+    <string name="settings_include_stories_title">包含限時動態</string>
+    <string name="settings_include_stories_description">計算瀏覽限時動態所花的時間，並套用目前的封鎖模式和時間限制。</string>
+    <string name="settings_include_stories_note">目前支援 Instagram。</string>
 </resources>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -38,4 +38,7 @@
         <item quantity="other">%1$d minutes</item>
     </plurals>
 
+    <string name="settings_include_stories_title">Include Stories</string>
+    <string name="settings_include_stories_description">Count time spent viewing Stories and apply your current blocking mode and limits.</string>
+    <string name="settings_include_stories_note">Currently supported on Instagram.</string>
 </resources>


### PR DESCRIPTION
This branch creates the first detect Stories option with support for Instagram as mentioned on #179 

This creates a new option in the settings where users can enable to also detect stories
In the future we might implement a initial animation or landing page where the user is aware that this exists instead of being buried in the settings

--- AI Generated Overview
This pull request introduces support for optionally blocking Instagram Stories, in addition to Reels, based on a new user setting. The changes span the accessibility service, data layer, and settings UI, ensuring that the "Include Stories" preference is persisted, observed, and applied during content detection. A new test verifies the correct behavior for Stories detection.

**Instagram Stories blocking and user setting integration:**

* Added a new `includeStories` user setting, including database migration, DAO methods, repository/store logic, and UI wiring, allowing users to choose whether Instagram Stories should be blocked alongside Reels. [[1]](diffhunk://#diff-ed92b8c194411dbb20fcc77d10ead35cfef384a1aee325c5068892be91517732L37-R37) [[2]](diffhunk://#diff-ed92b8c194411dbb20fcc77d10ead35cfef384a1aee325c5068892be91517732R307-R312) [[3]](diffhunk://#diff-4f87ba554e27638df0ea0186c8ef3bcebdde2e9177e8f3d134d405e6488fa262R133-R138) [[4]](diffhunk://#diff-afc35bde7b64511b89a2f649532eeeaacc88b851a8820a25bbde94d1f9f1d45cR58) [[5]](diffhunk://#diff-5572841f1ec5c9f38b91860e7591b608fb7587bae88677a38ce8c8ef8cc385c4R52-R58) [[6]](diffhunk://#diff-5572841f1ec5c9f38b91860e7591b608fb7587bae88677a38ce8c8ef8cc385c4R153-R159) [[7]](diffhunk://#diff-f04b3f61c2773fb39a450eb04ef127b6f1aae7bbe2999e8635ef609f9ee4f4e7R48-R50) [[8]](diffhunk://#diff-3c0b5d42439aeb5f4f1d517b9cf12b8de49b852f25be1f7293cfae16226724a2R85)
* Updated the accessibility service (`ContentScanner` and `ScrollessBlockAccessibilityService`) to pass and observe the `includeStories` flag, and to adjust detection logic so Stories are included/excluded according to user preference. [[1]](diffhunk://#diff-c4f22e6d22267702f3237009a2f801c700dafd9596bf895f9112472147c9e161R44) [[2]](diffhunk://#diff-c4f22e6d22267702f3237009a2f801c700dafd9596bf895f9112472147c9e161L259-R277) [[3]](diffhunk://#diff-c4f22e6d22267702f3237009a2f801c700dafd9596bf895f9112472147c9e161L317-R333) [[4]](diffhunk://#diff-c4f22e6d22267702f3237009a2f801c700dafd9596bf895f9112472147c9e161L340-R354) [[5]](diffhunk://#diff-c4f22e6d22267702f3237009a2f801c700dafd9596bf895f9112472147c9e161L368-R382) [[6]](diffhunk://#diff-1639f3e890c9545cc40044792a0bdc82164ce010334ccf694228fdb1d8f2d832L138-R138) [[7]](diffhunk://#diff-1639f3e890c9545cc40044792a0bdc82164ce010334ccf694228fdb1d8f2d832R155) [[8]](diffhunk://#diff-1639f3e890c9545cc40044792a0bdc82164ce010334ccf694228fdb1d8f2d832R271-R278)

**Detection logic improvements:**

* Enhanced the detection method for `BlockableApp.REELS` to optionally include Stories by combining detection rules when the setting is enabled. Refactored related methods to accept and propagate the detection method. [[1]](diffhunk://#diff-13117df57a4f86fedb766523bb52cbbf1be83046456d99043b89f90ccf4aeabbR133-R138) [[2]](diffhunk://#diff-13117df57a4f86fedb766523bb52cbbf1be83046456d99043b89f90ccf4aeabbL233-R239) [[3]](diffhunk://#diff-13117df57a4f86fedb766523bb52cbbf1be83046456d99043b89f90ccf4aeabbL252-R279)

**Testing:**

* Added `InstagramStoriesTest` to verify that Stories are only detected and blocked when the setting is enabled, and that Reels detection is unaffected.

**Database migration:**

* Introduced Room database migration `MIGRATION_10_11` to add the `include_stories` column to user settings, and registered the migration. [[1]](diffhunk://#diff-ed92b8c194411dbb20fcc77d10ead35cfef384a1aee325c5068892be91517732R307-R312) [[2]](diffhunk://#diff-f4d0d2376a8ffa37c25903d9424aec7e7b1186b68b7d32e5c6cbc873107361c7R73)